### PR TITLE
Set compilation-mode in *Gofmt Errors* window before display-buffer

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -572,8 +572,8 @@ buffer."
     (insert "gofmt errors:\n")
     (while (search-forward-regexp (concat "^\\(" (regexp-quote tmpfile) "\\):") nil t)
       (replace-match (file-name-nondirectory filename) t t nil 1))
-    (display-buffer errbuf)
-    (compilation-mode)))
+    (compilation-mode)
+    (display-buffer errbuf)))
 
 ;;;###autoload
 (defun gofmt-before-save ()


### PR DESCRIPTION
Set compilation mode before calling display-buffer because
display-buffer does not select the window, which can cause that the mode
is selected in the wrong buffer (i.e. when using popwin.el).
