### PR TITLE
Use "point" argument instead of return value of point function

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1004,7 +1004,7 @@ description at POINT."
                            "-f"
                            (file-truename (buffer-file-name (go--coverage-origin-buffer)))
                            "-o"
-                           (number-to-string (go--position-bytes (point))))
+                           (number-to-string (go--position-bytes point)))
       (with-current-buffer outbuf
         (split-string (buffer-substring-no-properties (point-min) (point-max)) "\n")))))
 


### PR DESCRIPTION
`point` argument is not used currently.
