### PR TITLE
Show longer godef output in a pop-up buffer

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1055,7 +1055,7 @@ available in the buffer `*godef describe*'"
         (if (not description)
             (message "No description found for expression at point")
           (display-message-or-buffer
-	   (format "%s" (mapconcat #'identity description "\n"))
+	   (mapconcat #'identity description "\n")
 	   "*godef describe*")))
     (file-error (message "Could not run godef binary"))))
 


### PR DESCRIPTION
This change helps when the output of `godef` is long, such as a struct with many elements. If the output is long, a new buffer is popped up, rather than trying to fit it all into the echo area. This is the same behaviour (and same implementation) as `shell-command` (`M-!`).
