### PR TITLE
Reuse func expressions for imenu. Fixes #57

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -850,7 +850,7 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
 
   (setq imenu-generic-expression
         '(("type" "^type *\\([^ \t\n\r\f]*\\)" 1)
-          ("func" "^func *\\(.*\\) {" 1)))
+          ("func" "^func *\\(.*[(,]\n?.*\\) {" 1)))
   (imenu-add-to-menubar "Index")
 
   ;; Go style


### PR DESCRIPTION
Use `go-func-regexp` and `go-func-meth-regexp` when matching functions in imenu.
