### PR TITLE
bug fix: end-of-defun no longer confused by "struct {" in args

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -549,12 +549,16 @@ current line will be returned."
     (if (not (looking-at "func"))
         (go-beginning-of-defun -1))
     ;; Find the { that starts the function, i.e., the next { that isn't
-    ;; preceded by struct or interface. Bugs: we can be defeated by
-    ;; mean-spirited comments (but that seems unlikely to occur in practice).
+    ;; preceded by struct or interface, or a comment or struct tag.  BUG:
+    ;; breaks if there's a comment between the struct/interface keyword and
+    ;; bracket, like this:
+    ;;
+    ;;     struct /* why? */ { 
     (while (progn
       (skip-chars-forward "^{")
       (forward-char)
-      (looking-back "\\(struct\\|interface\\)\\s-*{")))
+      (or (go-in-string-or-comment-p)
+          (looking-back "\\(struct\\|interface\\)\\s-*{"))))
     (setq orig-level (go-paren-level))
     (while (>= (go-paren-level) orig-level)
       (skip-chars-forward "^}")

--- a/movement_tests/functions.go
+++ b/movement_tests/functions.go
@@ -1,6 +1,6 @@
 // This file can be used to manually test that go-beginning-of-def and
 // go-end-of-defun are correct by entering into each function and mark-defun
-// (C-M-h)
+// (C-M-h).
 package main
 
 type typea int
@@ -35,19 +35,25 @@ type typeb struct {
 	a, b, c int
 }
 
-// Function with a pathological comment that breaks go-end-of-defun.
-func comment(a chan struct /* why? */ {
+// comment1 breaks end-of-defun by splitting "struct" from "{". (This also
+// apparently breaks gofmt, is why this is formatted so weird.)
+func comment1(a chan struct /* why? */ {
 
 }) {
 	close(a)
 }
 
-// Another function with a comment that breaks go-end-of-defun.
-func anotherComment(a struct {
-	b int // this b is sad :{
+func comment2(a struct {
+	b int // b is sad :{
 	c int
 }) {
 	a.b += a.c
 	a.c += a.b
 	return
+}
+
+func structWithTag(a chan struct {
+	v int `{`
+}) {
+	close(a)
 }


### PR DESCRIPTION
fixes #34
