### PR TITLE
Use utf-8 when calling godef

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1314,7 +1314,9 @@ description at POINT."
       (error "godef does not reliably work in XEmacs, expect bad results"))
   (if (not (buffer-file-name (go--coverage-origin-buffer)))
       (error "Cannot use godef on a buffer without a file name")
-    (let ((outbuf (get-buffer-create "*godef*")))
+    (let ((outbuf (get-buffer-create "*godef*"))
+          (coding-system-for-read 'utf-8)
+          (coding-system-for-write 'utf-8))
       (with-current-buffer outbuf
         (erase-buffer))
       (call-process-region (point-min)


### PR DESCRIPTION
Without this emacs might decide to write with a different coding system depending on the user's configuration and the godef -o offset might be incorrect
