### PR TITLE
godef-command, godef binary customization, variable added.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -204,6 +204,11 @@ a before-save-hook."
           (const :tag "None" nil))
   :group 'go)
 
+(defcustom godef-command "godef"
+  "The 'godef' command."
+  :type 'string
+  :group 'go)
+
 (defcustom go-other-file-alist
   '(("_test\\.go\\'" (".go"))
     ("\\.go\\'" ("_test.go")))
@@ -1321,7 +1326,7 @@ description at POINT."
         (erase-buffer))
       (call-process-region (point-min)
                            (point-max)
-                           "godef"
+                           godef-command
                            nil
                            outbuf
                            nil


### PR DESCRIPTION
There is no way to use godef related staff if godef binary is not in $PATH. So, I've made it customizable in analogy with gofmt. 