### PR TITLE
match identifiers, not type names, when highlighting struct literal

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -329,7 +329,7 @@ For mode=set, all covered lines will have this weight."
      (,(concat (go--regexp-enclose-in-symbol "type") "[[:space:]]+\\([^[:space:]]+\\)") 1 font-lock-type-face) ;; types
      (,(concat (go--regexp-enclose-in-symbol "type") "[[:space:]]+" go-identifier-regexp "[[:space:]]*" go-type-name-regexp) 1 font-lock-type-face) ;; types
      (,(concat "[^[:word:][:multibyte:]]\\[\\([[:digit:]]+\\|\\.\\.\\.\\)?\\]" go-type-name-regexp) 2 font-lock-type-face) ;; Arrays/slices
-     (,(concat "\\(" go-type-name-regexp "\\)" "{") 1 font-lock-type-face)
+     (,(concat "\\(" go-identifier-regexp "\\)" "{") 1 font-lock-type-face)
      (,(concat (go--regexp-enclose-in-symbol "map") "\\[[^]]+\\]" go-type-name-regexp) 1 font-lock-type-face) ;; map value type
      (,(concat (go--regexp-enclose-in-symbol "map") "\\[" go-type-name-regexp) 1 font-lock-type-face) ;; map key type
      (,(concat (go--regexp-enclose-in-symbol "chan") "[[:space:]]*\\(?:<-[[:space:]]*\\)?" go-type-name-regexp) 1 font-lock-type-face) ;; channel type


### PR DESCRIPTION
In code like `foo(&T{})`, we want to highlight T. We only want to
highlight struct literals, which can only be T or &T. Commit
3fb128afb93780e1b768b552137c950074e78129 changed this fontification rule
to match type names instead of identifiers. The difference is, that type
names may be prefixed with an asterisk or opening parenthesis, which
would lead to matching the opening parenthesis in the function call.
Revert this change.

/cc @rui314