### PR TITLE
RFC: Provide HTML option for godoc.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -208,6 +208,17 @@ a `before-save-hook'."
           (const :tag "None" nil))
   :group 'go)
 
+(defcustom godoc-command "godoc"
+  "The 'godoc' command."
+  :type 'string
+  :group 'go)
+
+(defcustom godoc-html nil
+  "Use HTML output of godoc.
+Requires `shr', which comes with Emacs 24.4 or newer."
+  :type 'boolean
+  :group 'go)
+
 (defcustom godef-command "godef"
   "The 'godef' command."
   :type 'string
@@ -1068,6 +1079,8 @@ you save any file, kind of defeating the point of autoloading."
   "Sentinel function run when godoc command completes."
   (with-current-buffer (process-buffer proc)
     (cond ((string= event "finished\n")  ;; Successful exit.
+           (when godoc-html
+             (shr-render-region (point-min) (point-max)))
            (goto-char (point-min))
            (view-mode 1)
            (display-buffer (current-buffer) t))
@@ -1083,7 +1096,7 @@ you save any file, kind of defeating the point of autoloading."
   (unless (string= query "")
     (set-process-sentinel
      (start-process-shell-command "godoc" (godoc--get-buffer query)
-                                  (concat "godoc " query))
+                                  (concat godoc-command " " (when godoc-html "-html ") query))
      'godoc--buffer-sentinel)
     nil))
 


### PR DESCRIPTION
This is more of an RFC for now. The patch works already and displays the HTML output. But it requires a bit more work to make internal links work.

Godoc supports HTML output, which can be rendered using Emacs'
shr.el (part of Emacs since 24.4 and available before in Gnus).  By
setting `godoc-html' to non-nil HTML output is used.

* go-mode.el (godoc-command): New defcustom.  More consistent.
 (godoc-html): New defcustom.
 (godoc--buffer-sentinel): Render HTML.
 (godoc): Add HTML support.