### PR TITLE
Fix go-unused-imports-line not to fail

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1311,9 +1311,11 @@ If IGNORE-CASE is non-nil, the comparison is case-insensitive."
   (reverse (remove nil
                    (mapcar
                     (lambda (line)
-                      (if (string-match "^\\(.+\\):\\([[:digit:]]+\\): imported and not used: \".+\".*$" line)
-                          (if (string= (file-truename (match-string 1 line)) (file-truename buffer-file-name))
-                              (string-to-number (match-string 2 line)))))
+                      (when (string-match "^\\(.+\\):\\([[:digit:]]+\\): imported and not used: \".+\".*$" line)
+                        (let ((error-file-name (match-string 1 line))
+                              (error-line-num (match-string 2 line)))
+                          (if (string= (file-truename error-file-name) (file-truename buffer-file-name))
+                              (string-to-number error-line-num)))))
                     (split-string (shell-command-to-string
                                    (concat go-command
                                            (if (string-match "_test\.go$" buffer-file-truename)


### PR DESCRIPTION
The function `go-unused-imports-line` raises the error `Wrong type argument: stringp, nil` in some environments. This error is caused by following mechanism:

* the following `file-truename` internally uses  `string-match` and overwrites the matching results
* the `match-string` function doesn't return a valid value.

This patch fixes the problem by saving the matching results in variables before calling the `file-truename` function.