### PR TITLE
Let godef--find-file-line-column return the current buffer

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1359,7 +1359,8 @@ visit FILENAME and go to line LINE and column COLUMN."
         (beginning-of-line)
         (forward-char (1- column))
         (if (buffer-modified-p)
-            (message "Buffer is modified, file position might not have been correct"))))))
+            (message "Buffer is modified, file position might not have been correct"))
+        (current-buffer)))))
 
 (defun godef--call (point)
   "Call godef, acquiring definition position and expression


### PR DESCRIPTION
With this change, the current-buffer is now returned out of godef-jump, which makes it much easier to integrate godef-jump with other libraries. For example, I use quick-jump:

    (defun my-go-quick-jump-push-def-hook (point)
      (interactive "d")
      (quick-jump-push-marker)
      (set-buffer (godef-jump point))
      (quick-jump-push-marker)
    )
    
    (defun my-go-mode-hook ()
      (local-set-key (kbd "M-.") 'my-go-quick-jump-push-def-hook)
    )
    (add-hook 'go-mode-hook 'my-go-mode-hook)

Without this change, I can't get the current-buffer that's been switched to once godef-jump returns, so anything that needs the new location doesn't work.

If there's a better way to do this, please let me know.