### PR TITLE
Use the updated github.com repo URL for godef.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ the following extra features to provide an improved experience:
   - `godef-describe` (`C-c C-d`) to describe expressions
   - `godef-jump` (`C-c C-j`) and `godef-jump-other-window` (`C-x 4 C-c
     C-j`) to jump to declarations
-  - This requires you to install godef via `go get
-  code.google.com/p/rog-go/exp/cmd/godef`.
+  - This requires you to install godef via `go get github.com/rogpeppe/godef`.
 - Basic support for imenu (functions and variables)
 - Built-in support for displaying code coverage as calculated by `go
   test` (`go-coverage`)


### PR DESCRIPTION
Namaste,

The code.google.com Website has been deprecated and will turn read-only soon.
The URL included no longer works. The updated URL is added here.

Cheers,
Yesudeep.