### PR TITLE
Change obsolete font-lock-syntactic-keywords to syntax-propertize-funtion.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -897,7 +897,7 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
   (set (make-local-variable 'parse-sexp-lookup-properties) t)
   (if (boundp 'syntax-propertize-function)
       (set (make-local-variable 'syntax-propertize-function) #'go-propertize-syntax)
-    (set (make-local-variable 'font-lock-syntactic-keywords)
+    (set (make-local-variable 'syntax-propertize-function)
          go--font-lock-syntactic-keywords)
     (set (make-local-variable 'font-lock-multiline) t))
 


### PR DESCRIPTION
I found warning message when I installed go-mode via ELPA

```
In go-mode:
go-mode.el:901:10:Warning: `font-lock-syntactic-keywords' is an obsolete
variable (as of 24.1); use `syntax-propertize-function' instead.
```