### PR TITLE
Add goto functions for working with function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,19 @@ the following extra features to provide an improved experience:
 - Basic support for imenu (functions and variables)
 - Built-in support for displaying code coverage as calculated by `go
   test` (`go-coverage`)
-- Several goto functions for manipulating function signatures:
+- Several goto functions for manipulating function signature of the method we
+  are currently editing:
   - Going to the arguments (`go-goto-arguments` - `C-c C-g a`)
-  - Going to the docstring, creating it if it does not exist and updating it
-    if the name does not match (`go-goto-docstring` - `C-c C-g d`)
+  - Going to the docstring, creating it if it does not exist
+    (`go-goto-docstring` - `C-c C-g d`). Skips anonymous functions.
   - Going to the function name (`go-goto-function-name` - `C-c C-g f`)
   - Going to the return value, adding space for adding one if there are none
     present (`go-goto-return-value` - `C-c C-g r`)
-  - Going to the type signature, adding parenthesis for adding one if there is
-    none present (`go-goto-type-signature` - `C-c C-g t`)
+  - Going to the method receiver, adding parenthesis for adding one if there is
+    none present (`go-goto-type-signature` - `C-c C-g m`). Skips anonymous
+    functions.
+  - All of the above accept one prefix argument (`C-u`), which if given makes
+    them skip anonymous functions and go directly to the root function.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ the following extra features to provide an improved experience:
   - `go-download-play` to download a Playground entry into a new
     buffer
 - Managing imports
-  - A function for jumping to the file's imports (`go-goto-imports`)
+  - A function for jumping to the file's imports (`go-goto-imports` -
+    `C-c C-g i`)
   - A function for adding imports, including tab completion
     (`go-import-add`, bound to `C-c C-a`)
   - A function for removing or commenting unused imports
@@ -40,6 +41,15 @@ the following extra features to provide an improved experience:
 - Basic support for imenu (functions and variables)
 - Built-in support for displaying code coverage as calculated by `go
   test` (`go-coverage`)
+- Several goto functions for manipulating function signatures:
+  - Going to the arguments (`go-goto-arguments` - `C-c C-g a`)
+  - Going to the docstring, creating it if it does not exist and updating it
+    if the name does not match (`go-goto-docstring` - `C-c C-g d`)
+  - Going to the function name (`go-goto-function-name` - `C-c C-g f`)
+  - Going to the return value, adding space for adding one if there are none
+    present (`go-goto-return-value` - `C-c C-g r`)
+  - Going to the type signature, adding parenthesis for adding one if there is
+    none present (`go-goto-type-signature` - `C-c C-g t`)
 
 # Installation
 

--- a/go-mode.el
+++ b/go-mode.el
@@ -600,7 +600,7 @@ current line will be returned."
     ;; breaks if there's a comment between the struct/interface keyword and
     ;; bracket, like this:
     ;;
-    ;;     struct /* why? */ { 
+    ;;     struct /* why? */ {
     (while (progn
       (skip-chars-forward "^{")
       (forward-char)

--- a/go-mode.el
+++ b/go-mode.el
@@ -1586,11 +1586,12 @@ are below that anonymous function, go to the root function."
         (looking-at "^//"))
       ;; In case we are looking at the docstring, move on forward until we are
       ;; not anymore
-      ;; TODO(thiderman): This would behave incorrectly if point is
-      ;; inside a standalone block of comments that are not a docstring.
       (beginning-of-line)
       (while (looking-at "^//")
-        (forward-line 1)))
+        (forward-line 1))
+      ;; If we are still not looking at a function, retry by calling self again.
+      (when (not (looking-at "^func"))
+        (go-goto-function)))
 
      ((not (looking-at "^func"))
       ;; If we are not looking at the beginning of a function line, do a regexp
@@ -1600,7 +1601,8 @@ are below that anonymous function, go to the root function."
       ;; If nothing is found, assume that we are at the top of the file and
       ;; should search forward instead.
       (when (not (looking-at "func"))
-        (re-search-forward "\\<func\\>" nil t))
+        (re-search-forward "\\<func\\>" nil t)
+        (forward-word -1))
 
       ;; If we have landed at an anonymous function, it is possible that we
       ;; were not inside it but below it. If we were not inside it, we should

--- a/go-mode.el
+++ b/go-mode.el
@@ -1624,8 +1624,9 @@ If the function is anonymous, place point on the 'func' keyword."
 If there is none, make space for one to be added."
   (interactive)
   (go-goto-arguments)
-  (re-search-forward ")" nil t)
-  (forward-char 1)
+  (backward-char)
+  (forward-list)
+  (forward-char)
 
   ;; Opening parenthesis, enter it
   (when (looking-at "(")

--- a/go-mode.el
+++ b/go-mode.el
@@ -1612,7 +1612,7 @@ If the function is anonymous, place point on the 'func' keyword."
         (forward-char 4)))))
 
 (defun go-goto-arguments ()
-  "Go to the return value declaration of the current function."
+  "Go to the arguments of the current function."
   (interactive)
   (go-goto-function-name)
   (forward-word 1)

--- a/go-mode.el
+++ b/go-mode.el
@@ -1712,21 +1712,31 @@ If there is none, add parenthesis to add one."
 (defun go-goto-docstring ()
   "Go to the top of the docstring of the current function.
 
-If there is none, add one."
+If there is none, add slashes to start writing one."
   (interactive)
   (go-goto-function)
   (forward-line -1)
   (beginning-of-line)
+
   (while (looking-at "^//")
     (forward-line -1))
-  (next-line 1)
+  (forward-line 1)
   (beginning-of-line)
-  (if (not (looking-at "^func"))
-      (forward-char 3)
-    ;; If we are still at the function signature, we should add a new docstring.
+
+  (cond
+   ;; If we are looking at an empty comment, add a single space in front of it.
+   ((looking-at "^//$")
+    (forward-char 2)
+    (insert " "))
+   ;; If we are not looking at the function signature, we are looking at a docstring.
+   ;; Move to the beginning of the first word of it.
+   ((not (looking-at "^func"))
+    (forward-char 3))
+   ;; If we are still at the function signature, we should add a new docstring.
+   (t
     (forward-line -1)
     (newline)
-    (insert (format "// %s " (go--get-function-name)))))
+    (insert (format "// %s " (go--get-function-name))))))
 
 (defun go--get-function-name ()
   "Return the current function name as a string"

--- a/go-mode.el
+++ b/go-mode.el
@@ -1636,8 +1636,8 @@ If there is none, make space for one to be added."
     (insert " ")
     (backward-char 1)))
 
-(defun go-goto-type-signature ()
-  "Go to the type signature of the current function.
+(defun go-goto-method-receiver ()
+  "Go to the receiver of the current method.
 
 If there is none, add parenthesis to add one."
   (interactive)
@@ -1680,8 +1680,8 @@ If there is none, add one."
 (define-key go-goto-map (kbd "d") 'go-goto-docstring)
 (define-key go-goto-map (kbd "f") 'go-goto-function-name)
 (define-key go-goto-map (kbd "i") 'go-goto-imports)
+(define-key go-goto-map (kbd "m") 'go-goto-method-receiver)
 (define-key go-goto-map (kbd "r") 'go-goto-return-value)
-(define-key go-goto-map (kbd "t") 'go-goto-type-signature)
 
 (provide 'go-mode)
 

--- a/go-mode.el
+++ b/go-mode.el
@@ -1757,7 +1757,7 @@ an error is raised."
    ;; If we are looking at an empty comment, add a single space in front of it.
    ((looking-at "^//$")
     (forward-char 2)
-    (insert (format " %s " (go--function-name))))
+    (insert (format " %s " (go--function-name t))))
    ;; If we are not looking at the function signature, we are looking at a docstring.
    ;; Move to the beginning of the first word of it.
    ((not (looking-at "^func"))
@@ -1766,15 +1766,20 @@ an error is raised."
    (t
     (forward-line -1)
     (newline)
-    (insert (format "// %s " (go--function-name))))))
+    (insert (format "// %s " (go--function-name t))))))
 
-(defun go--function-name ()
+(defun go--function-name (&optional arg)
   "Return the current function name as a string.
 
-Will skip anonymous functions since they do not have names."
-  (save-excursion
-    (go-goto-function-name t)
-    (symbol-name (symbol-at-point))))
+If `arg' is non-nil anonymous functions will be ignored and the
+name returned will be of the top-level function.
+
+Returns nil otherwise."
+  (when (or (not (go--in-anonymous-funcion-p))
+            arg)
+    (save-excursion
+      (go-goto-function-name t)
+      (symbol-name (symbol-at-point)))))
 
 (defun go--in-anonymous-funcion-p ()
   "Return t if point is inside an anonymous function, nil otherwise."

--- a/go-mode.el
+++ b/go-mode.el
@@ -1630,9 +1630,6 @@ If there is none, make space for one to be added."
   ;; Opening parenthesis, enter it
   (when (looking-at "(")
     (forward-char 1))
-  ;; First item is a pointer, move past the pointer
-  (when (looking-at "*")
-    (forward-char 1))
   ;; No return arguments, add space for adding
   (when (looking-at "{")
     (insert " ")

--- a/go-mode.el
+++ b/go-mode.el
@@ -1617,7 +1617,8 @@ If ARG is non-nil, anonymous functions are ignored."
       ;; If we have landed at an anonymous function, it is possible that we
       ;; were not inside it but below it. If we were not inside it, we should
       ;; go to the containing function.
-      (while (not (go--in-function-p p))
+      (while (and (not (go--in-function-p p))
+                  (not (looking-at "^func")))
         (go-goto-function arg)))))
 
   (cond

--- a/go-mode.el
+++ b/go-mode.el
@@ -1641,18 +1641,10 @@ If ARG is non-nil, anonymous functions are ignored."
     (forward-char 1))
 
    ((not (looking-at "{"))
-    ;; Place point at the next curly brace.
-    (search-forward "{")
+    ;; Go to the end of the defun and back up and we'll be where we want to be.
+    (end-of-defun)
     (backward-char 1)
-    ;; Check of the end of the other parenthesis looks like "} {". If it does,
-    ;; we are looking at the definition of an anonymous intefrace return value.
-    ;; Move past the list and one char forward and we are done.
-    (when (save-excursion
-            (forward-list 1)
-            (backward-char 1)
-            (looking-at "} {"))
-      (forward-list 1)
-      (forward-char 1)))))
+    (backward-list 1))))
 
 (defun go--in-function-p (compare-point)
   "Return t if COMPARE-POINT lies inside the function immediately surrounding point."

--- a/go-mode.el
+++ b/go-mode.el
@@ -1617,7 +1617,7 @@ If one prefix argument is given, anonymous functions are skipped."
     ;; If we are still in a comment, redo the call so that we get out of it.
     (go-goto-function arg))
 
-   ((and (looking-at "func(") (equal arg '(4)))
+   ((and (looking-at "func(") arg)
     ;; If we are looking at an anonymous function and a prefix argument has
     ;; been supplied, redo the call so that we skip the anonymous function.
     (go-goto-function arg))))
@@ -1721,7 +1721,7 @@ an error is raised."
              (go--in-anonymous-funcion-p))
     (error "Anonymous functions cannot have method receivers"))
 
-  (go-goto-function '(4))  ; Always skip anonymous functions
+  (go-goto-function t)  ; Always skip anonymous functions
   (forward-char 5)
   (when (not (looking-at "("))
     (save-excursion
@@ -1742,7 +1742,7 @@ an error is raised."
              (go--in-anonymous-funcion-p))
     (error "Anonymous functions do not have docstrings"))
 
-  (go-goto-function '(4))
+  (go-goto-function t)
   (forward-line -1)
   (beginning-of-line)
 
@@ -1771,7 +1771,7 @@ an error is raised."
 
 Will skip anonymous functions since they do not have names."
   (save-excursion
-    (go-goto-function-name '(4))
+    (go-goto-function-name t)
     (symbol-name (symbol-at-point))))
 
 (defun go--in-anonymous-funcion-p ()

--- a/go-mode.el
+++ b/go-mode.el
@@ -1609,7 +1609,7 @@ If one prefix argument is given, anonymous functions are skipped."
       ;; If we have landed at an anonymous function, it is possible that we
       ;; were not inside it but below it. If we were not inside it, we should
       ;; go to the containing function.
-      (while (go--in-function-p p)
+      (while (go--below-anonymous-function p)
         (go-goto-function arg)))))
 
   (cond
@@ -1622,8 +1622,8 @@ If one prefix argument is given, anonymous functions are skipped."
     ;; been supplied, redo the call so that we skip the anonymous function.
     (go-goto-function arg))))
 
-(defun go--in-function-p (compare-point)
-  "Return t if `compare-point' is inside the function that point is currently on.
+(defun go--below-anonymous-function (compare-point)
+  "Return t if `compare-point' is below the function that point is currently on.
 This should only be called as a helper when point is looking at \"func\".
 
 Returns nil in all other cases."

--- a/go-mode.el
+++ b/go-mode.el
@@ -1718,6 +1718,7 @@ an error is raised."
   (interactive "P")
 
   (when (and (not (called-interactively-p 'interactive))
+             (not arg)
              (go--in-anonymous-funcion-p))
     (error "Anonymous functions cannot have method receivers"))
 
@@ -1739,6 +1740,7 @@ an error is raised."
   (interactive "P")
 
   (when (and (not (called-interactively-p 'interactive))
+             (not arg)
              (go--in-anonymous-funcion-p))
     (error "Anonymous functions do not have docstrings"))
 

--- a/go-mode.el
+++ b/go-mode.el
@@ -1695,6 +1695,10 @@ If there is none, make space for one to be added."
 
 If there is none, add parenthesis to add one."
   (interactive)
+
+  (when (go--in-anonymous-funcion-p)
+    (error "Anonymous functions cannot have method receivers"))
+
   (go-goto-function)
   (forward-char 5)
   (when (not (looking-at "("))
@@ -1726,6 +1730,12 @@ If there is none, add one."
   (save-excursion
     (go-goto-function-name)
     (symbol-name (symbol-at-point))))
+
+(defun go--in-anonymous-funcion-p ()
+  "Return t if point is inside an anonymous function, nil otherwise."
+  (save-excursion
+    (go-goto-function)
+    (looking-at "func(")))
 
 (define-prefix-command 'go-goto-map)
 (define-key go-mode-map (kbd "C-c C-g") 'go-goto-map)

--- a/go-mode.el
+++ b/go-mode.el
@@ -1568,9 +1568,6 @@ for."
       (if (not (eq cur-buffer (current-buffer)))
           (display-buffer (current-buffer) `(,go-coverage-display-buffer-func))))))
 
-(define-prefix-command 'go-goto-map)
-(define-key go-mode-map (kbd "C-c C-g") 'go-goto-map)
-
 (defun go-goto-function ()
   "Go to the function defintion above point.
 
@@ -1614,16 +1611,12 @@ If the function is anonymous, place point on the 'func' keyword."
       (when (looking-at "Test")
         (forward-char 4)))))
 
-(define-key go-goto-map (kbd "f") 'go-goto-function-name)
-
 (defun go-goto-arguments ()
   "Go to the return value declaration of the current function."
   (interactive)
   (go-goto-function-name)
   (forward-word 1)
   (forward-char 1))
-
-(define-key go-goto-map (kbd "a") 'go-goto-arguments)
 
 (defun go-goto-return-value ()
   "Go to the return value declaration of the current function.
@@ -1645,11 +1638,6 @@ If there is none, make space for one to be added."
     (insert " ")
     (backward-char 1)))
 
-(define-key go-goto-map (kbd "r") 'go-goto-return-value)
-
-;; Since this is already defined, just add the key to it.
-(define-key go-goto-map (kbd "i") 'go-goto-imports)
-
 (defun go-goto-type-signature ()
   "Go to the type signature of the current function.
 
@@ -1661,8 +1649,6 @@ If there is none, add parenthesis to add one."
     (save-excursion
       (insert "() ")))
   (forward-char 1))
-
-(define-key go-goto-map (kbd "t") 'go-goto-type-signature)
 
 (defun go-goto-docstring ()
   "Go to the top of the docstring of the current function.
@@ -1683,13 +1669,21 @@ If there is none, add one."
     (newline)
     (insert (format "// %s " (go--get-function-name)))))
 
-(define-key go-goto-map (kbd "d") 'go-goto-docstring)
-
 (defun go--get-function-name ()
   "Return the current function name as a string"
   (save-excursion
     (go-goto-function-name)
     (symbol-name (symbol-at-point))))
+
+(define-prefix-command 'go-goto-map)
+(define-key go-mode-map (kbd "C-c C-g") 'go-goto-map)
+
+(define-key go-goto-map (kbd "a") 'go-goto-arguments)
+(define-key go-goto-map (kbd "d") 'go-goto-docstring)
+(define-key go-goto-map (kbd "f") 'go-goto-function-name)
+(define-key go-goto-map (kbd "i") 'go-goto-imports)
+(define-key go-goto-map (kbd "r") 'go-goto-return-value)
+(define-key go-goto-map (kbd "t") 'go-goto-type-signature)
 
 (provide 'go-mode)
 

--- a/go-mode.el
+++ b/go-mode.el
@@ -1755,7 +1755,7 @@ an error is raised."
    ;; If we are looking at an empty comment, add a single space in front of it.
    ((looking-at "^//$")
     (forward-char 2)
-    (insert (format " %s " (go--get-function-name))))
+    (insert (format " %s " (go--function-name))))
    ;; If we are not looking at the function signature, we are looking at a docstring.
    ;; Move to the beginning of the first word of it.
    ((not (looking-at "^func"))
@@ -1764,9 +1764,9 @@ an error is raised."
    (t
     (forward-line -1)
     (newline)
-    (insert (format "// %s " (go--get-function-name))))))
+    (insert (format "// %s " (go--function-name))))))
 
-(defun go--get-function-name ()
+(defun go--function-name ()
   "Return the current function name as a string.
 
 Will skip anonymous functions since they do not have names."

--- a/go-mode.el
+++ b/go-mode.el
@@ -1731,7 +1731,7 @@ an error is raised."
 (defun go-goto-docstring (&optional arg)
   "Go to the top of the docstring of the current function.
 
-If there is none, add slashes to start writing one.
+If there is none, add one beginning with the name of the current function.
 
 Anonymous functions do not have docstrings, so when this is called
 interactively anonymous functions will be skipped. If called programmatically,
@@ -1755,7 +1755,7 @@ an error is raised."
    ;; If we are looking at an empty comment, add a single space in front of it.
    ((looking-at "^//$")
     (forward-char 2)
-    (insert " "))
+    (insert (format " %s " (go--get-function-name))))
    ;; If we are not looking at the function signature, we are looking at a docstring.
    ;; Move to the beginning of the first word of it.
    ((not (looking-at "^func"))

--- a/go-mode.el
+++ b/go-mode.el
@@ -1591,16 +1591,16 @@ If ARG is non-nil, anonymous functions are ignored."
       (while (looking-at "^//")
         (forward-line 1))
       ;; If we are still not looking at a function, retry by calling self again.
-      (when (not (looking-at "func"))
+      (when (not (looking-at "\\<func\\>"))
         (go-goto-function arg)))
 
      ;; If we're already looking at an anonymous func, look for the
      ;; surrounding function.
-     ((and (looking-at "func")
-           (not (looking-at "^func")))
+     ((and (looking-at "\\<func\\>")
+           (not (looking-at "^func\\>")))
       (re-search-backward "\\<func\\>" nil t))
 
-     ((not (looking-at "func"))
+     ((not (looking-at "\\<func\\>"))
       ;; If point is on the "func" keyword, step back a word and retry
       (if (string= (symbol-name (symbol-at-point)) "func")
           (backward-word)
@@ -1610,7 +1610,7 @@ If ARG is non-nil, anonymous functions are ignored."
 
       ;; If nothing is found, assume that we are at the top of the file and
       ;; should search forward instead.
-      (when (not (looking-at "func"))
+      (when (not (looking-at "\\<func\\>"))
         (re-search-forward "\\<func\\>" nil t)
         (forward-word -1))
 
@@ -1618,7 +1618,7 @@ If ARG is non-nil, anonymous functions are ignored."
       ;; were not inside it but below it. If we were not inside it, we should
       ;; go to the containing function.
       (while (and (not (go--in-function-p p))
-                  (not (looking-at "^func")))
+                  (not (looking-at "^func\\>")))
         (go-goto-function arg)))))
 
   (cond
@@ -1626,7 +1626,7 @@ If ARG is non-nil, anonymous functions are ignored."
     ;; If we are still in a comment, redo the call so that we get out of it.
     (go-goto-function arg))
 
-   ((and (looking-at "func(") arg)
+   ((and (looking-at "\\<func(") arg)
     ;; If we are looking at an anonymous function and a prefix argument has
     ;; been supplied, redo the call so that we skip the anonymous function.
     (go-goto-function arg))))
@@ -1645,7 +1645,7 @@ If ARG is non-nil, anonymous functions are ignored."
 (defun go--in-function-p (compare-point)
   "Return t if COMPARE-POINT lies inside the function immediately surrounding point."
   (save-excursion
-    (when (not (looking-at "func"))
+    (when (not (looking-at "\\<func\\>"))
       (go-goto-function))
     (let ((start (point)))
       (go--goto-opening-curly-brace)
@@ -1664,14 +1664,14 @@ If the function is anonymous, place point on the 'func' keyword.
 
 If one prefix argument is given, anonymous functions are skipped."
   (interactive "P")
-  (when (not (looking-at "func"))
+  (when (not (looking-at "\\<func\\>"))
     (go-goto-function arg))
   ;; If we are looking at func( we are on an anonymous function and
   ;; nothing else should be done.
-  (when (not (looking-at "func("))
+  (when (not (looking-at "\\<func("))
     (let ((words 1)
           (chars 1))
-      (when (looking-at "func (")
+      (when (looking-at "\\<func (")
         (setq words 3
               chars 2))
       (forward-word words)
@@ -1792,7 +1792,7 @@ Returns nil otherwise."
   "Return t if point is inside an anonymous function, nil otherwise."
   (save-excursion
     (go-goto-function)
-    (looking-at "func(")))
+    (looking-at "\\<func(")))
 
 (define-prefix-command 'go-goto-map)
 (define-key go-mode-map (kbd "C-c C-g") 'go-goto-map)

--- a/go-mode.el
+++ b/go-mode.el
@@ -1636,11 +1636,23 @@ If ARG is non-nil, anonymous functions are ignored."
   ;; Try to place the point on the opening brace.
   (cond
    ((looking-at "(")
+    ;; Multiple return values! Just walk past the list and we're done!
     (forward-list 1)
     (forward-char 1))
+
    ((not (looking-at "{"))
-    (forward-word 1)
-    (forward-char 1))))
+    ;; Place point at the next curly brace.
+    (search-forward "{")
+    (backward-char 1)
+    ;; Check of the end of the other parenthesis looks like "} {". If it does,
+    ;; we are looking at the definition of an anonymous intefrace return value.
+    ;; Move past the list and one char forward and we are done.
+    (when (save-excursion
+            (forward-list 1)
+            (backward-char 1)
+            (looking-at "} {"))
+      (forward-list 1)
+      (forward-char 1)))))
 
 (defun go--in-function-p (compare-point)
   "Return t if COMPARE-POINT lies inside the function immediately surrounding point."

--- a/go-mode.el
+++ b/go-mode.el
@@ -1615,28 +1615,31 @@ are below that anonymous function, go to the root function."
     (go-goto-function)))
 
 (defun go--in-function-p (compare-point)
-  "Return t if point is inside the function that starts at `compare-point', nil
-otherwise."
-  ;; Check that we are not looking at a top level function. If we are,
-  (when (not (looking-at "^func"))
-   (save-excursion
-     (go--goto-return-values)
-     ;; Try to place the point on the opening brace
-     (cond
-      ((looking-at "(")
-       (forward-list 1)
-       (forward-char 1))
-      ((not (looking-at "{"))
-       (forward-word 1)
-       (forward-char 1)))
+  "Return t if `compare-point' is inside the function that point is currently on.
+This should only be called as a helper when point is looking at \"func\".
 
-     (when (looking-at "{")
-       ;; Go past the body of the function and back inside of it.
-       (forward-list 1)
-       (backward-char 1)
-       ;; Finally, compare if our position is past the assert point.
-       ;; Return t if it is.
-       (< (point) compare-point)))))
+Returns nil in all other cases."
+  ;; Check that we are not looking at a top level function. If we are, return nil.
+  (when (not (looking-at "^func"))
+    (save-excursion
+      (go--goto-return-values)
+      ;; Try to place the point on the opening brace.
+      (cond
+       ((looking-at "(")
+        (forward-list 1)
+        (forward-char 1))
+       ((not (looking-at "{"))
+        (forward-word 1)
+        (forward-char 1)))
+
+      (when (looking-at "{")
+        ;; Go past the body of the function and back inside of it.
+        (forward-list 1)
+        (backward-char 1)
+        ;; Now that point is looking at the closing brace of the function
+        ;; body, compare if our position is earlier in the file than the
+        ;; comparing point. Return t if it is.
+        (< (point) compare-point)))))
 
 (defun go-goto-function-name ()
   "Go to the name of the current function.

--- a/go-mode.el
+++ b/go-mode.el
@@ -1662,7 +1662,7 @@ If ARG is non-nil, anonymous functions are ignored."
 If the function is a test, place point after 'Test'.
 If the function is anonymous, place point on the 'func' keyword.
 
-If one prefix argument is given, anonymous functions are skipped."
+If ARG is non-nil, anonymous functions are skipped."
   (interactive "P")
   (when (not (looking-at "\\<func\\>"))
     (go-goto-function arg))
@@ -1682,7 +1682,7 @@ If one prefix argument is given, anonymous functions are skipped."
 (defun go-goto-arguments (&optional arg)
   "Go to the arguments of the current function.
 
-If one prefix argument is given, anonymous functions are skipped."
+If ARG is non-nil, anonymous functions are skipped."
   (interactive "P")
   (go-goto-function-name arg)
   (forward-word 1)
@@ -1701,7 +1701,7 @@ If one prefix argument is given, anonymous functions are skipped."
 If there are multiple ones contained in a parenthesis, enter the parenthesis.
 If there is none, make space for one to be added.
 
-If one prefix argument is given, anonymous functions are skipped."
+If ARG is non-nil, anonymous functions are skipped."
   (interactive "P")
   (go--goto-return-values arg)
 
@@ -1721,7 +1721,7 @@ If there is none, add parenthesis to add one.
 
 Anonymous functions cannot have method receivers, so when this is called
 interactively anonymous functions will be skipped. If called programmatically,
-an error is raised."
+an error is raised unless ARG is non-nil."
   (interactive "P")
 
   (when (and (not (called-interactively-p 'interactive))
@@ -1743,7 +1743,7 @@ If there is none, add one beginning with the name of the current function.
 
 Anonymous functions do not have docstrings, so when this is called
 interactively anonymous functions will be skipped. If called programmatically,
-an error is raised."
+an error is raised unless ARG is non-nil."
   (interactive "P")
 
   (when (and (not (called-interactively-p 'interactive))
@@ -1776,12 +1776,12 @@ an error is raised."
     (insert (format "// %s " (go--function-name t))))))
 
 (defun go--function-name (&optional arg)
-  "Return the current function name as a string.
+  "Return the name of the surrounding function.
 
-If `arg' is non-nil anonymous functions will be ignored and the
-name returned will be of the top-level function.
-
-Returns nil otherwise."
+If ARG is non-nil, anonymous functions will be ignored and the
+name returned will be that of the top-level function. If ARG is
+nil and the surrounding function is anonymous, nil will be
+returned."
   (when (or (not (go--in-anonymous-funcion-p))
             arg)
     (save-excursion


### PR DESCRIPTION
Add several functions:
- `go-goto-arguments`
- `go-goto-docstring`
- `go-goto-function`
- `go-goto-function-name`
- `go-goto-return-value`
- `go-goto-type-signature`

They are all about going to different parts of function signatures, with
their names being self descriptive. They all operate on the current
function, the definition of which is "the closest `func` statement above
point". If no `func` is found above point, the functions will jump to
the first `func` in the file. Lastly, if the point is in the docstring
of a function, the goto functions will operate on that function and not
the function above.go-goto-type-signature

Additionally, some of the functions will create their targets if they are
missing:
- `go-goto-docstring` will create a docstring if it does not
  exist as well as update the docstring name for a function that has been
  renamed.
- `go-goto-return-value` will add space for adding return values.
- `go-goto-type-signature` will add spaces and a pair of parenthesis for
  adding a signature.

It should also be noted that the functions have been tested with
anonymous functions as well.

Add keymap at `C-c g` for goto functions.
Add mapping for the already existing `go-goto-imports` at `C-c g i`.
Add helper function `go--get-function-name`, which grabs the string of
the function above point.

Update README to reflect the addition of these functions.

---

I have been using these functions for about a month now. They feel stable enough that they can be shared with the upstream `go-mode`.

It should be noted and is probably apparent that this is my first real contribution to a project written in elisp (or any lisp at all, actually :dancer:). As such, I am probably missing out on conventions, useful functions and other such things. I'd be very happy to change the code so that it fits well into the project! Comments on coding style and such things are extremely welcome!

---

## TODO

- [x] `go-goto-docstring` should not update the docstring
- [x] Keybinds should not be on the user bindable keyspace.
- [x] Move all `define-key` to one single place.
- [x] `go-goto-arguments` has a copy-pasted docstring
- [x] ~~Handle going to docstrings with prepending words (`A foo` etc)~~
- [x] Fix corner cases for `go-goto-function`
- [x] Don't skip past the pointer in `go-goto-return-value`
- [x] Use `forward-list` instead of searching for `)`.
- [x] `go-goto-type-signature` has the wrong name.
- [x] Docstring and comments for `go--in-function-p` are wrong
- [x] `go-goto-docstring` has a bug with empty comments above a function
- [x] Add prefix arguments and handling of special cases for anonymous functions
- [x] Fix bug in `go-goto-docstring` in the empty comments case
- [x] Remove `get-` from `go--get-function-name`
- [x] Handle prefix arguments as booleans
- [x] Fix logical errors in `go--in-function`
- [x] Handle prefixed non-interactive calls to `go-goto-docstring` and `go-goto-method-receiver`.
- [x] Make `go--function-name` return `nil` for anonymous functions.