### PR TITLE
go-search-package helps you remember long import urls

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1834,6 +1834,27 @@ returned."
     (go-goto-function)
     (looking-at "\\<func(")))
 
+
+(defun go-search-package (target-pkg)
+  "Search for an import url for a package named like TARGET-PKG.
+This function calls the unix find(1) utility, so feel free to use any
+form of regular expression that find would understand.
+
+This function makes use of other functions defined in go-mode.el, make sure you
+(require 'go-mode) before running this.
+"
+  (interactive "sPackage name: ")
+  (let* ((previous-working-directory (getenv "PWD"))
+	(gopath (cadr (go-root-and-paths)))
+	(default-directory (concat gopath "/pkg/linux_amd64/")) ;; CHANGE THIS!!
+	(results-buffer (get-buffer-create "*Go packages search result*")))
+    (progn
+      (switch-to-buffer results-buffer)
+      (erase-buffer)
+      (call-process "find" nil results-buffer t "."  "-type" "d" "-name" (concat "*" target-pkg "*"))
+      (view-mode))))
+
+
 (provide 'go-mode)
 
 ;;; go-mode.el ends here

--- a/go-mode.el
+++ b/go-mode.el
@@ -1834,26 +1834,19 @@ returned."
     (go-goto-function)
     (looking-at "\\<func(")))
 
-
 (defun go-search-package (target-pkg)
-  "Search for an import url for a package named like TARGET-PKG.
-This function calls the unix find(1) utility, so feel free to use any
-form of regular expression that find would understand.
-
-This function makes use of other functions defined in go-mode.el, make sure you
-(require 'go-mode) before running this.
-"
+  "Search for an import url for a package named like TARGET-PKG."
   (interactive "sPackage name: ")
-  (let* ((previous-working-directory (getenv "PWD"))
-	(gopath (cadr (go-root-and-paths)))
-	(default-directory (concat gopath "/pkg/linux_amd64/")) ;; CHANGE THIS!!
-	(results-buffer (get-buffer-create "*Go packages search result*")))
+  (require 'go-mode)
+  (let* ((results-buffer (get-buffer-create "*Go packages search result*"))
+          (packages-list  (go-packages-go-list)))
     (progn
       (switch-to-buffer results-buffer)
       (erase-buffer)
-      (call-process "find" nil results-buffer t "."  "-type" "d" "-name" (concat "*" target-pkg "*"))
+      (mapcar (lambda (package-name)
+         (if (string-match target-pkg package-name)
+             (insert (concat package-name "\n")))) packages-list)
       (view-mode))))
-
 
 (provide 'go-mode)
 


### PR DESCRIPTION
Hi, I wrote this small functions in order to find import-urls automatically.

## Rationale 
The use case is to avoid having to remember long import urls like

+ github.com/jinzhu/gorm
+ github.com/gin-gonic/contrib/sessions

And in general, to avoid having to shell-out to `go list` and/or having to leave emacs in general.


## Description
The go-search-package will look among the installed packages for an
import-url for a given package name.

This is useful in order to avoid to have to copy-paste import urls
every time.

## Possible improvements
As of now, it calls the `go-packages-go-list` every time, and I don't think this is a good behaviour.

I decided not to create some `go-package-list` variable because the list of installed packages might vary between when such variable is populated and when my function (or other function) is ran.

It might be a good idea though to create such a variable and to provide another function like `go-update-packages-lists` so that such list must not be re-computed every time.

## Possible further developments

It would be cool to have autocompletion for packages, but this is out of scope.