### PR TITLE
Fix filename replacement in gofmt error buffer

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1117,8 +1117,12 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
               (search-forward "flag provided but not defined: -srcdir" nil t)))
           (insert "Your version of goimports is too old and doesn't support vendoring. Please update goimports!\n\n"))
       (insert "gofmt errors:\n")
-      (while (search-forward-regexp (concat "^\\(" (regexp-quote tmpfile) "\\):") nil t)
-        (replace-match (file-name-nondirectory filename) t t nil 1))
+      (let ((truefile
+             (if (gofmt--is-goimports-p)
+                 (concat (file-name-directory filename) (file-name-nondirectory tmpfile))
+               tmpfile)))
+        (while (search-forward-regexp (concat "^\\(" (regexp-quote truefile) "\\):") nil t)
+          (replace-match (file-name-nondirectory filename) t t nil 1)))
       (compilation-mode)
       (display-buffer errbuf))))
 


### PR DESCRIPTION
Hi, thanks for go-mode, it's a critical part of my dev tooling! goimport's new `-srcdir` option rewrites the temp directory path with the original source directory but leaves the temporary `gofmtXXXX.go` filename which breaks regex replacement in `gofmt--process-errors`. Here's a patch to fix that.