### PR TITLE
Update URL for gogetdoc

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -321,7 +321,7 @@ Consider using godoc-gogetdoc instead for more accurate results."
 (defun godoc-gogetdoc (point)
   "Use the gogetdoc tool to find the documentation for an identifier.
 
-You can install gogetdoc with 'go get github.com/rogpeppe/godef'."
+You can install gogetdoc with 'go get -u github.com/zmb3/gogetdoc'."
   (if (not (buffer-file-name (go--coverage-origin-buffer)))
       ;; TODO: gogetdoc supports unsaved files, but not introducing
       ;; new artifical files, so this limitation will stay for now.


### PR DESCRIPTION
Also reccomend use of the -u flag for `go get` since
gogetdoc requires a reasonably up-to-date version of
golang.org/x/tools.