### PR TITLE
Fix non-existing function being used in go-unused-imports-lines

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1474,7 +1474,7 @@ archive files in /pkg/"
                               (string-to-number error-line-num)))))
                     (split-string (shell-command-to-string
                                    (concat go-command
-                                           (if (string-match "_test\\.go$" buffer-file-truename)
+                                           (if (string-match "_test\\.go$" buffer-file-name)
                                                " test -c"
                                              (concat " build -o " null-device))
                                            " -gcflags=-e"


### PR DESCRIPTION
I've noticed that non-existing buffer-file-truename function is used
while browsing the source code. I beleive buffer-file-name should be
used instead. I haven't tested the change though.