### PR TITLE
Fix go-goto-arguments when in subword-mode

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1835,7 +1835,7 @@ If ARG is non-nil, anonymous functions are skipped."
 If ARG is non-nil, anonymous functions are skipped."
   (interactive "P")
   (go-goto-function-name arg)
-  (forward-word 1)
+  (forward-word-strictly 1)
   (forward-char 1))
 
 (defun go--goto-return-values (&optional arg)


### PR DESCRIPTION
When calling `go-goto-arguments` in a CamelCase function with at least two words, the point doesn't go to the first argument.
