### PR TITLE
Do not set indent-tabs-mode global

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1058,9 +1058,6 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
           ("func" "^func *\\(.*\\) {" 1)))
   (imenu-add-to-menubar "Index")
 
-  ;; Go style
-  (setq indent-tabs-mode t)
-
   ;; Handle unit test failure output in compilation-mode
   ;;
   ;; Note that we add our entry to the beginning of


### PR DESCRIPTION
Go uses tab for indentation, so go-mode set `indent-tabs-mode`,
sounds good. But it leads to un-expected behavior when assigning
text to variable, like:

```
var _ = `
    x
`
```

There, we expect 4 spaces follow by x but we get a tab follow by x.

We have `gofmt` for formatting our file, so do not need
`indent-tabs-mode`.

Fix https://github.com/dominikh/go-mode.el/issues/153