### PR TITLE
Make go-guru-build-tags a list of strings

### DIFF
--- a/go-guru.el
+++ b/go-guru.el
@@ -70,9 +70,9 @@
   nil
   "History of values supplied to `go-guru-set-scope'.")
 
-(defcustom go-guru-build-tags ""
+(defcustom go-guru-build-tags '()
   "Build tags passed to guru."
-  :type 'string
+  :type '(repeat string)
   :group 'go-guru)
 
 (defface go-guru-hl-identifier-face


### PR DESCRIPTION
Previously, go-guru-build-tags was a single string.  This commit fixes a stack trace generated by `go-guru--command` if
go-guru-build-tags is set to any value other than the default empty
string.

Fixes #156 
