### PR TITLE
Use a named function for before-change-functions.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -955,6 +955,12 @@ Function result is a unparenthesized type or a parameter list."
          (go--match-parameter-list end))
         (t nil)))
 
+(defun go--reset-dangling-cache-before-change (&optional unused-beg unused-end)
+  "Reset `go-dangling-cache'.
+
+This is intended to be called from `before-change-functions'."
+  (setq go-dangling-cache (make-hash-table :test 'eql)))
+
 ;;;###autoload
 (define-derived-mode go-mode prog-mode "Go"
   "Major mode for editing Go source text.
@@ -1048,7 +1054,7 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
   (set (make-local-variable 'compilation-error-screen-columns) nil)
 
   (set (make-local-variable 'go-dangling-cache) (make-hash-table :test 'eql))
-  (add-hook 'before-change-functions (lambda (x y) (setq go-dangling-cache (make-hash-table :test 'eql))) t t)
+  (add-hook 'before-change-functions #'go--reset-dangling-cache-before-change t t)
 
   ;; ff-find-other-file
   (setq ff-other-file-alist 'go-other-file-alist)


### PR DESCRIPTION
Create go--reset-dangling-cache-before-change and add that to
before-change-functions, rather than adding a lambda.  The effect is the
same, but this allows people to easily find the file responsible when
looking at before-change-functions in Emacs' help system (such as with
describe-variable).