### PR TITLE
use forward-word-strictly when available

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -50,6 +50,12 @@
 (defmacro go--has-syntax-propertize-p ()
   (boundp 'syntax-propertize-function))
 
+(eval-when-compile
+  (defmacro go--forward-word (&optional arg)
+   (if (fboundp 'forward-word-strictly)
+       `(forward-word-strictly ,arg)
+     `(forward-word ,arg))))
+
 (defun go--delete-whole-line (&optional arg)
   "Delete the current line without putting it in the `kill-ring'.
 Derived from function `kill-whole-line'.  ARG is defined as for that
@@ -1768,7 +1774,7 @@ If ARG is non-nil, anonymous functions are ignored."
       ;; should search forward instead.
       (when (not (looking-at "\\<func\\>"))
         (re-search-forward "\\<func\\>" nil t)
-        (forward-word -1))
+        (go--forward-word -1))
 
       ;; If we have landed at an anonymous function, it is possible that we
       ;; were not inside it but below it. If we were not inside it, we should
@@ -1834,7 +1840,7 @@ If ARG is non-nil, anonymous functions are skipped."
       (when (looking-at "\\<func (")
         (setq words 3
               chars 2))
-      (forward-word words)
+      (go--forward-word words)
       (forward-char chars)
       (when (looking-at "Test")
         (forward-char 4)))))
@@ -1845,7 +1851,7 @@ If ARG is non-nil, anonymous functions are skipped."
 If ARG is non-nil, anonymous functions are skipped."
   (interactive "P")
   (go-goto-function-name arg)
-  (forward-word 1)
+  (go--forward-word 1)
   (forward-char 1))
 
 (defun go--goto-return-values (&optional arg)


### PR DESCRIPTION
This is just a follow up to the previous pull request.  It just
introduces a simple macro to use forward-word-strictly when 
it is bound.

`go-goto-function-name` and the like don't work properly in 
emacs >= 25 with `subword-mode` when types are camelCased,
eg,

```
func (list *LinkedList) Sum() int {
	// point
}
```
