### PR TITLE
Fix off-by-one in point calculations

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1478,7 +1478,8 @@ description at POINT."
                                "-f"
                                (file-truename (buffer-file-name (go--coverage-origin-buffer)))
                                "-o"
-                               (number-to-string (position-bytes point)))
+                               ;; Emacs point and byte positions are 1-indexed.
+                               (number-to-string (1- (position-bytes point))))
           (with-current-buffer outbuf
             (split-string (buffer-substring-no-properties (point-min) (point-max)) "\n"))
         (kill-buffer outbuf)))))


### PR DESCRIPTION
Emacs point is 1-indexed rather than 0-indexed. As a result, calling
`godef-jump` on the following code:

```go
 foo|(bar) // assuming | is point
```

would find the definition of `bar` rather than `foo`.