### PR TITLE
gopkgs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ the following extra features to provide an improved experience:
   - A function for jumping to the file's imports (`go-goto-imports` -
     `C-c C-f i`)
   - A function for adding imports, including tab completion
-    (`go-import-add`, bound to `C-c C-a`)
+    (`go-import-add`, bound to `C-c C-a`). Setting `go-packages-function` variable
+    allows to use custom search command to find available packages.
+    Possible values are: `go-packages-native`, `go-packages-go-list`, [go-packages-gopkgs](https://github.com/tpng/gopkgs)
   - A function for removing or commenting unused imports
     (`go-remove-unused-imports`)
 - Integration with godef

--- a/go-mode.el
+++ b/go-mode.el
@@ -1398,8 +1398,12 @@ It looks for archive files in /pkg/."
    #'string<))
 
 (defun go-packages-go-list ()
-  "Return a list of all Go packages, using `go list'."
+  "Return a list of all Go packages, using 'go list'."
   (process-lines go-command "list" "-e" "all"))
+
+(defun go-packages-gopkgs ()
+  "Return a list of all Go packages, using 'gopkgs'."
+  (process-lines "gopkgs"))
 
 (defun go-unused-imports-lines ()
   (reverse (remove nil


### PR DESCRIPTION
Since my emacs go-import-add started to response slowly I found this way to improve performance. 
gopkgs works way much faster compared to native and go list funcs.