### PR TITLE
Evaluate error conditions before prompting for new name in go-rename

### DIFF
--- a/go-rename.el
+++ b/go-rename.el
@@ -40,8 +40,10 @@
   "Rename the entity denoted by the identifier at point, using
 the `gorename' tool. With FORCE, call `gorename' with the
 `-force' flag."
-  (interactive (list (read-string "New name: " (thing-at-point 'symbol))
-                     current-prefix-arg))
+  (interactive (list
+                (unless (buffer-modified-p (or (not buffer-file-name)))
+                  (read-string "New name: " (thing-at-point 'symbol)))
+                current-prefix-arg))
   (if (not buffer-file-name)
       (error "Cannot use go-rename on a buffer without a file name"))
   ;; It's not sufficient to save the current buffer if modified,


### PR DESCRIPTION
It's super annoying to get the error "Please save the current buffer before invoking go-rename" after creating a new name just to save and do everything all over again. This PR fixes this by returning the error immediately before prompting for a new name if the buffer is not saved or the buffer is not a file buffer. 

To test, open a file, edit something *without* saving and then try to invoke `go-rename`. The error should then pop-up immediately without the prompt for a new name. Saving the file and retrying `go-rename` will make it behave as expected.