### PR TITLE
Skip spaces at the point before jumping to a definition

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1516,7 +1516,9 @@ description at POINT."
   "Jump to the definition of the expression at POINT."
   (interactive "d")
   (condition-case nil
-      (let ((file (car (godef--call point))))
+      (let* ((delta (skip-chars-forward "[:space:]"))
+             (new-point (+ point delta))
+             (file (car (godef--call new-point))))
         (if (not (godef--successful-p file))
             (message "%s" (godef--error file))
           (push-mark)


### PR DESCRIPTION
If there are spaces in the current line between the point and a function, then skip these spaces and then jump to the definition of the function.