### PR TITLE
move to godef result line/column by with-current-buffer

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1454,12 +1454,12 @@ visit FILENAME and go to line LINE and column COLUMN."
     (let ((filename (match-string 1 specifier))
           (line (string-to-number (match-string 2 specifier)))
           (column (string-to-number (match-string 3 specifier))))
-      (funcall (if other-window #'find-file-other-window #'find-file) filename)
-      (go--goto-line line)
-      (beginning-of-line)
-      (forward-char (1- column))
-      (if (buffer-modified-p)
-          (message "Buffer is modified, file position might not have been correct")))))
+      (with-current-buffer (funcall (if other-window #'find-file-other-window #'find-file) filename)
+        (go--goto-line line)
+        (beginning-of-line)
+        (forward-char (1- column))
+        (if (buffer-modified-p)
+            (message "Buffer is modified, file position might not have been correct"))))))
 
 (defun godef--call (point)
   "Call godef, acquiring definition position and expression


### PR DESCRIPTION
When finished to `find-file` for godef result file, It's not sure that `current-buffer` is the file.
Therefore, we should use `with-current-buffer` when move to the line and column of godef result.