### PR TITLE
Treat _ as a symbol constituent

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -386,8 +386,7 @@ For mode=set, all covered lines will have this weight."
     (modify-syntax-entry ?\' "\"" st)
     (modify-syntax-entry ?`  "\"" st)
     (modify-syntax-entry ?\\ "\\" st)
-    ;; TODO make _ a symbol constituent now that xemacs is gone
-    (modify-syntax-entry ?_  "w" st)
+    (modify-syntax-entry ?_  "_" st)
 
     st)
   "Syntax table for Go mode.")


### PR DESCRIPTION
This allows users to navigate in FOO_BAR by word. Previously, it would
move across the whole FOO_BAR.

This is recommended by Stefan Monnier, the former GNU Emacs
maintainer:
https://emacs.stackexchange.com/questions/1075/whats-the-difference-between-words-and-symbols#comment2567_1077