### PR TITLE
Include the column number in the parsing for unused imports

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1408,7 +1408,7 @@ It looks for archive files in /pkg/."
   (reverse (remove nil
                    (mapcar
                     (lambda (line)
-                      (when (string-match "^\\(.+\\):\\([[:digit:]]+\\): imported and not used: \".+\".*$" line)
+                      (when (string-match "^\\(.+\\):\\([[:digit:]]+\\):[[:digit:]]: imported and not used: \".+\".*$" line)
                         (let ((error-file-name (match-string 1 line))
                               (error-line-num (match-string 2 line)))
                           (if (string= (file-truename error-file-name) (file-truename buffer-file-name))

--- a/go-mode.el
+++ b/go-mode.el
@@ -1408,7 +1408,7 @@ It looks for archive files in /pkg/."
   (reverse (remove nil
                    (mapcar
                     (lambda (line)
-                      (when (string-match "^\\(.+\\):\\([[:digit:]]+\\):[[:digit:]]: imported and not used: \".+\".*$" line)
+                      (when (string-match "^\\(.+?\\):\\([[:digit:]]+\\):\\([[:digit:]]+:\\)? imported and not used: \".+\".*$" line)
                         (let ((error-file-name (match-string 1 line))
                               (error-line-num (match-string 2 line)))
                           (if (string= (file-truename error-file-name) (file-truename buffer-file-name))


### PR DESCRIPTION
I've found that the output of `go build` includes a column number as part of the output and so `go-remove-unused-imports` is failing to match the output for the given regexp.

I've included and additional `:[[:digit:]]` check in the regexp which is now matching my `go build` output and removing imports.

FYI; I'm using go version 1.9.2