### PR TITLE
Enhance imenu support

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1065,7 +1065,7 @@ from https://github.com/lukehoban/go-outline."
                   (mapc (lambda (entry)
                             (let* ((label (cdr (assoc "label" entry)))
                                    (type (cdr (assoc "type" entry)))
-                                   (pos (cdr (assoc "start" entry)))
+                                   (pos (byte-to-position (cdr (assoc "start" entry))))
                                    (receiverType (when (assoc "receiverType" entry)
                                                    (cdr (assoc "receiverType" entry))))
                                    (index-name (if receiverType


### PR DESCRIPTION
Use [go-outline](https://github.com/lukehoban/go-outline) to enhance imenu support, and automatically downgrade to the original implementation when the go-outline is unavailable or any error occurs.