### PR TITLE
recommend a hook that doesn't break autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ and close integration with familiar Emacs functionality (for example
 syntax-based navigation like `beginning-of-defun`), go-mode comes with
 the following extra features to provide an improved experience:
 
-- Integration with `gofmt` by providing a command of the same name,
-  and `gofmt-before-save`, which can be used in a hook to format Go
-  buffers before saving them.
+- Integration with `gofmt` by providing a command of the same name.
+  This can be run before saving Go buffers by adding the following to your init file:
+  `(add-hook 'go-mode-hook (lambda () (add-hook 'before-save-hook 'gofmt nil t)))`
   - Setting the `gofmt-command` variable also allows using
     `goimports`.
   - Setting the `gofmt-args` variable with a list of arguments allows

--- a/go-mode.el
+++ b/go-mode.el
@@ -933,7 +933,7 @@ The following extra functions are defined:
 If you want to automatically run `gofmt' before saving a file,
 add the following hook to your emacs configuration:
 
-\(add-hook 'before-save-hook #'gofmt-before-save)
+\(add-hook 'go-mode-hook (lambda () (add-hook 'before-save-hook 'gofmt nil t)))
 
 If you want to use `godef-jump' instead of etags (or similar),
 consider binding godef-jump to `M-.', which is the default key
@@ -1153,6 +1153,10 @@ you save any file, kind of defeating the point of autoloading."
 
   (interactive)
   (when (eq major-mode 'go-mode) (gofmt)))
+
+(make-obsolete 'gofmt-before-save
+               "`gofmt-before-save' breaks autoloading. You should use \"(add-hook 'go-mode-hook (lambda () (add-hook 'before-save-hook 'gofmt nil t)))\" instead"
+               "v1.6.0")
 
 (defun godoc--read-query ()
   "Read a godoc query from the minibuffer."


### PR DESCRIPTION
Instead of recommending a hook that runs for every mode and exits if
the current mode isn't go-mode, recommend a hook that runs for go-mode
and adds a local before-save-hook that runs gofmt