### PR TITLE
rm incorrect filename quoting in godoc-gogetdoc

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -277,7 +277,7 @@ You can install gogetdoc with 'go get -u github.com/zmb3/gogetdoc'."
       ;; TODO: gogetdoc supports unsaved files, but not introducing
       ;; new artifical files, so this limitation will stay for now.
       (error "Cannot use gogetdoc on a buffer without a file name"))
-  (let ((posn (format "%s:#%d" (shell-quote-argument (file-truename buffer-file-name)) (1- (position-bytes point))))
+  (let ((posn (format "%s:#%d" (file-truename buffer-file-name) (1- (position-bytes point))))
         (out (godoc--get-buffer "<at point>")))
   (with-current-buffer (get-buffer-create "*go-gogetdoc-input*")
     (setq buffer-read-only nil)


### PR DESCRIPTION
This makes it work on Windows as well.  Confer issue #215.