### PR TITLE
Always move back to same column after applying rcs patch

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1029,7 +1029,8 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
         ;; Appending lines decrements the offset (possibly making it
         ;; negative), deleting lines increments it. This order
         ;; simplifies the forward-line invocations.
-        (line-offset 0))
+        (line-offset 0)
+        (column (current-column)))
     (save-excursion
       (with-current-buffer patch-buffer
         (goto-char (point-min))
@@ -1056,7 +1057,8 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
                 (cl-incf line-offset len)
                 (go--delete-whole-line len)))
              (t
-              (error "Invalid rcs patch or internal error in go--apply-rcs-patch")))))))))
+              (error "Invalid rcs patch or internal error in go--apply-rcs-patch")))))))
+    (move-to-column column)))
 
 (defun gofmt--is-goimports-p ()
   (string-equal (file-name-base gofmt-command) "goimports"))


### PR DESCRIPTION
Previously the point would move to the beginning of the line if the
current line was changed by gofmt because save-execution stores a text
marker instead of a buffer position.