### PR TITLE
Fix local variables list.

### DIFF
--- a/go-guru.el
+++ b/go-guru.el
@@ -552,9 +552,9 @@ end point."
 
 (provide 'go-guru)
 
-;; Local variables:
+;; Local Variables:
 ;; indent-tabs-mode: t
 ;; tab-width: 8
-;; End
+;; End:
 
 ;;; go-guru.el ends here


### PR DESCRIPTION
This avoids a compiler warning that the variable list isn't properly terminated.