### PR TITLE
Added TRAMP support in godef--call

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1479,13 +1479,45 @@ description at POINT."
                             "-f" localname
                             "-o" (number-to-string (go--position-bytes (point))))
               (with-current-buffer outbuf
+                (setq result (tramp-make-tramp-file-name method user domain host port 
+                                                         (buffer-substring-no-properties (point-min) (point-max))))))    
+          (progn (process-file godef-command nil outbuf nil
+                               "-f" filename
+                               "-o" (number-to-string (go--position-bytes (point))))
+                 (with-current-buffer outbuf
+                   (setq result (buffer-substring-no-properties (point-min) (point-max))))))
+        (kill-buffer outbuf)
+        (split-string result "\n")))))
+
+
+(defun godef--call (point)
+  "Call godef, acquiring definition position and expression
+description at POINT."
+  (if (not (buffer-file-name (go--coverage-origin-buffer)))
+      (error "Cannot use godef on a buffer without a file name")
+    (let ((outbuf (generate-new-buffer "*godef*"))
+          (coding-system-for-read 'utf-8)
+          (coding-system-for-write 'utf-8))
+      (let ((filename (file-truename (buffer-file-name (go--coverage-origin-buffer)))))
+        (if (tramp-tramp-file-p filename)
+            (with-parsed-tramp-file-name filename nil
+              (message (tramp-make-tramp-file-name method user domain host port ""))
+              (process-file godef-command nil outbuf nil
+                            "-f" localname
+                            "-o" (number-to-string (go--position-bytes (point))))
+              (with-current-buffer outbuf
                 (split-string (tramp-make-tramp-file-name method user domain host port 
                                                           (buffer-substring-no-properties (point-min) (point-max))) "\n")))    
           (progn (process-file godef-command nil outbuf nil
                                "-f" filename
                                "-o" (number-to-string (go--position-bytes (point))))
                  (with-current-buffer outbuf
-                   (split-string (buffer-substring-no-properties (point-min) (point-max)) "\n"))))))))
+                   (split-string (buffer-substring-no-properties (point-min) (point-max)) "\n")))))
+      (prog2
+          
+          (with-current-buffer outbuf
+            (split-string (buffer-substring-no-properties (point-min) (point-max)) "\n"))
+        (kill-buffer outbuf)))))
 
 (defun godef--successful-p (output)
   (not (or (string= "-" output)

--- a/go-mode.el
+++ b/go-mode.el
@@ -1466,8 +1466,6 @@ visit FILENAME and go to line LINE and column COLUMN."
 (defun godef--call (point)
   "Call godef, acquiring definition position and expression
 description at POINT."
-  (if (go--xemacs-p)
-      (error "godef does not reliably work in XEmacs, expect bad results"))
   (if (not (buffer-file-name (go--coverage-origin-buffer)))
       (error "Cannot use godef on a buffer without a file name")
     (let ((outbuf (get-buffer-create "*godef*")))


### PR DESCRIPTION
I am not very experienced elisp programmer, so sorry if my attempt is not perfect.. 

I found that by using `process-file` instead of `call-process-region`, godef-jump works for me over tramp connection. Please review and see if this helps others as well.

This should solve #46 