### PR TITLE
Fix go-remove-unused-imports

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1410,7 +1410,7 @@ It looks for archive files in /pkg/."
   (reverse (remove nil
                    (mapcar
                     (lambda (line)
-                      (when (string-match "^\\(.+\\):\\([[:digit:]]+\\): imported and not used: \".+\".*$" line)
+                      (when (string-match "^\\(.+\\):\\([[:digit:]]+\\):\\([[:digit:]]+\\): imported and not used: \".+\".*$" line)
                         (let ((error-file-name (match-string 1 line))
                               (error-line-num (match-string 2 line)))
                           (if (string= (file-truename error-file-name) (file-truename buffer-file-name))


### PR DESCRIPTION
Digging into https://github.com/dominikh/go-mode.el/issues/221, it looks like
https://github.com/golang/go/commit/9fda4df9a0d3ef2dd0dc649e174992bc2d2f8db2#diff-b8f2a4b5c283e605d42f9f0232a611f3R1047 introduced `line:column` output to the `go build` output (`lico`):

- https://github.com/golang/go/blob/5ad0a524d23b9b69c8c3caddbdf2dfe235c4d725/src/cmd/internal/src/xpos.go#L13
- https://github.com/golang/go/blob/master/src/cmd/internal/src/pos.go#L14-L30)

This appears to have shipped in Go 1.9, released 2017-08, which predates the earlier issue filed here in 2017-11.

Accounting for the additional column output fixes the issue.

Given:

```go
package main

import (
	"os"
)

func main() {
}
```

```sh
$ go build ./main.go
./main.go:7:2: imported and not used: "os"
```

Current regular expression:

```lisp
(let ((line "./main.go:7:2: imported and not used: \"os\""))
  (when (string-match "^\\(.+\\):\\([[:digit:]]+\\): imported and not used: \".+\".*$" line)
    (let ((error-file-name (match-string 1 line))
          (error-line-num (match-string 2 line)))
      (message "%s %s" error-file-name error-line-num))))

;; "./main.go:7 2"
```

`./main.go:7` is not a real file name and `go-remove-unused-imports` fails.

Fixed regular expression:

```lisp
(let ((line "./main.go:7:2: imported and not used: \"os\""))
  (when (string-match "^\\(.+\\):\\([[:digit:]]+\\):\\([[:digit:]]+\\): imported and not used: \".+\".*$" line)
    (let ((error-file-name (match-string 1 line))
          (error-line-num (match-string 2 line)))
      (message "%s %s" error-file-name error-line-num))))

;; "./main.go 7"
```

Which removes `"os"` as expected.
