### PR TITLE
require subr-x when interpreting go-guru.el

### DIFF
--- a/go-guru.el
+++ b/go-guru.el
@@ -143,6 +143,8 @@
   (completing-read-multiple "guru-scope (comma-separated): "
                             (go-packages) nil nil nil 'go-guru--scope-history))
 
+(eval-when-compile (require 'subr-x))
+
 ;;;###autoload
 (defun go-guru-set-scope ()
   "Set the scope for the Go guru, prompting the user to edit the previous scope.


### PR DESCRIPTION
Otherwise the user will run into the following error when trying to use
`go-guru-set-scope':

  Symbol’s function definition is void: string-join

This doesn't affect compiled files.

[fixes #258]