### PR TITLE
Strip vendor package name in go-packages

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -2036,7 +2036,7 @@ If BUFFER, return the number of characters in that buffer instead."
 
 (defun go--current-workspace ()
   "Return a current project workspace (GOPATH)."
-  (cl-find-if (lambda (x) (string-prefix-p x buffer-file-name))
+  (cl-find-if (lambda (x) (go--string-prefix-p x buffer-file-name))
               (mapcar 'expand-file-name (cdr (go-root-and-paths)))))
 
 ;; Polyfills for functions added in Emacs 26.  Remove these once we don’t


### PR DESCRIPTION
When using [Vendor directories](https://golang.org/cmd/go/#hdr-Vendor_Directories), `go-packages` suggest a package name including a project name like a `github.com/buzztaiki/usedep/vendor/github.com/golang/glog`.

This PR strip preceding paths from vendoring package name in `go-packages`.
I think that it is useful when to use vendoring support tool like a dep.