### PR TITLE
Fix go-rename when buffer is not visiting any file

### DIFF
--- a/go-rename.el
+++ b/go-rename.el
@@ -41,7 +41,7 @@
 the `gorename' tool. With FORCE, call `gorename' with the
 `-force' flag."
   (interactive (list
-                (unless (buffer-modified-p (or (not buffer-file-name)))
+                (if (and buffer-file-name (not (buffer-modified-p)))
                   (read-string "New name: " (thing-at-point 'symbol)))
                 current-prefix-arg))
   (if (not buffer-file-name)


### PR DESCRIPTION
Fix the following error when calling `go-rename` in a buffer that is not visiting any file:

    Wrong type argument: bufferp, t

After this change, `go-rename` will instead print the following message:

    Cannot use go-rename on a buffer without a file name
    
Follow-up to https://github.com/dominikh/go-mode.el/pull/196.

* `go-rename.el` (`go-rename`): Fix the interactive form's check for the condition that the buffer is not visiting a file.