### PR TITLE
Update default for godoc-and-godef-command

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -221,15 +221,13 @@ Set this to nil to upload without prompting.
 
 (defcustom godoc-command "go doc"
   "Which executable to use for `godoc'.
-This can either be 'godoc' or 'go doc', both as an absolute path
-or an executable in PATH."
+This can be either an absolute path or an executable in PATH."
   :type 'string
   :group 'go)
 
-(defcustom godoc-and-godef-command "godoc"
-  "Which executable to use for `godoc' in `godoc-and-godef-command'.
-Must be 'godoc' and not 'go doc' and can be an absolute path or
-an executable in PATH."
+(defcustom godoc-and-godef-command "go doc"
+  "Which executable to use for `godoc-and-godef'.
+This can be either an absolute path or an executable in PATH."
   :type 'string
   :group 'go)
 


### PR DESCRIPTION
Starting with Go 1.12, the `godoc` command no longer has a
command-line interface (its only a webserver). That
broke (godoc-and-godef) by default.

Originally `godoc` and `go doc` had non-overlapping features which is
why we kept this as `godoc` when we switched 'godoc-command over to
`go doc`. Since that time it looks like the things we need are now
supported in `go doc`, namely you can give `go doc` a filesystem path
instead of a package name.

Fixes #262