### PR TITLE
Fix indent for case statement comments

### DIFF
--- a/test/testdata/indentation_tests/switch.go
+++ b/test/testdata/indentation_tests/switch.go
@@ -29,4 +29,38 @@ func main() {
 		"hi",
 		"there":
 	}
+
+	switch {
+	// attached
+	case true:
+		// body
+		code()
+		// could go either way
+	case true:
+	// could go either way
+	case true:
+		// could go both ways
+	// could go both ways
+	case true:
+
+	/* this works too */
+	case true:
+
+	/* hi */
+	/* this works too */
+	case true:
+
+	/* hi
+	   this works too */
+	case true:
+
+	// could go either way
+	case true:
+
+		// could go either way
+	case true:
+
+	// also works
+	default:
+	}
 }


### PR DESCRIPTION
Try to replicate gofmt behavior. In particular (assuming there are no
non-comment lines between comment in question and proceeding "case"):
- comments above first "case" always align with case
- comments between a case-aligned comment and the proceeding "case"
  always align with the "case"
- all other cases are ambiguous, so if comment is aligned with "case"
  or with the case block, maintain the indent, otherwise default
  indent to the case block