### PR TITLE
Add major mode for go.mod files: go-dot-mod-mode

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -2635,11 +2635,11 @@ If BUFFER, return the number of characters in that buffer instead."
 
 (defconst go-dot-mod-mode-keywords
   '("module" "go" "require" "replace" "exclude")
-  "All keywords in the Go language.  Used for font locking.")
+  "All keywords for go.mod files.  Used for font locking.")
 
 (defvar go-dot-mod-font-lock-keywords
   `(
-    (,(concat "\\_<" (regexp-opt go-dot-mod-mode-keywords t) "\\_>") . font-lock-keyword-face))
+    (,(concat "^\\s-*" (regexp-opt go-dot-mod-mode-keywords t) "\\s-") . font-lock-keyword-face))
   "Keyword highlighting specification for `go-dot-mod-mode'.")
 
 ;;;###autoload

--- a/go-mode.el
+++ b/go-mode.el
@@ -2620,6 +2620,50 @@ If BUFFER, return the number of characters in that buffer instead."
   (with-current-buffer (or buffer (current-buffer))
     (1- (position-bytes (point-max)))))
 
+(defvar go-dot-mod-mode-map
+  (let ((map (make-sparse-keymap)))
+    map)
+  "Keymap for `go-dot-mod-mode'.")
+
+(defvar go-dot-mod-mode-syntax-table
+  (let ((st (make-syntax-table)))
+    ;; handle '//' comment syntax
+    (modify-syntax-entry ?/ ". 124b" st)
+    (modify-syntax-entry ?\n "> b" st)
+    st)
+  "Syntax table for `go-dot-mod-mode'.")
+
+(defconst go-dot-mod-mode-keywords
+  '("module" "go" "require" "replace" "exclude")
+  "All keywords in the Go language.  Used for font locking.")
+
+(defvar go-dot-mod-font-lock-keywords
+  `(
+    (,(concat "\\_<" (regexp-opt go-dot-mod-mode-keywords t) "\\_>") . font-lock-keyword-face))
+  "Keyword highlighting specification for `go-dot-mod-mode'.")
+
+;;;###autoload
+(define-derived-mode go-dot-mod-mode fundamental-mode "Go Mod"
+  "A major mode for editing go.mod files."
+  :syntax-table go-dot-mod-mode-syntax-table
+  (set (make-local-variable 'comment-start) "// ")
+  (set (make-local-variable 'comment-end)   "")
+  (set (make-local-variable 'comment-use-syntax) t)
+  (set (make-local-variable 'comment-start-skip) "\\(//+\\)\\s *")
+
+  (set (make-local-variable 'font-lock-defaults)
+       '(go-dot-mod-font-lock-keywords))
+  (set (make-local-variable 'indent-line-function) 'go-mode-indent-line)
+
+  ;; Go style
+  (setq indent-tabs-mode t)
+
+  ;; we borrow the go-mode-indent function so we need this buffer cache
+  (set (make-local-variable 'go-dangling-cache) (make-hash-table :test 'eql))
+  (add-hook 'before-change-functions #'go--reset-dangling-cache-before-change t t))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("go\\.mod\\'" . go-dot-mod-mode))
 
 ;; Polyfills for functions added in Emacs 26.  Remove these once we don’t
 ;; support Emacs 25 any more.

--- a/test/go-indentation-test.el
+++ b/test/go-indentation-test.el
@@ -16,6 +16,14 @@
         (indent-region (point-min) (point-max) nil)
         (should (string= contents-before-indent (buffer-string)))))))
 
+(ert-deftest go-dot-mod--indent-line ()
+  (with-temp-buffer
+    (go-dot-mod-mode)
+    (insert-file-contents "testdata/indentation_tests/go.mod")
+    (let ((contents-before-indent (buffer-string)))
+      (indent-region (point-min) (point-max) nil)
+      (should (string= contents-before-indent (buffer-string))))))
+
 (defun go--should-indent (input expected)
   "Run `indent-region' against INPUT and make sure it matches EXPECTED."
   (with-temp-buffer

--- a/test/testdata/indentation_tests/go.mod
+++ b/test/testdata/indentation_tests/go.mod
@@ -1,0 +1,19 @@
+module my/thing
+
+// comment
+go 1.12
+
+require other/thing v1.0.2
+require new/thing/v2 v2.3.4
+exclude old/thing v1.2.3
+replace bad/thing v1.4.5 => good/thing v1.4.5
+
+require (
+	// comment inside block
+	new/thing v2.3.4
+	old/thing v1.2.3
+)
+
+replace (
+	bad/thing v1.4.5 => good/thing v1.4.5
+)


### PR DESCRIPTION
This is a simple major mode for go.mod files. It's named
go-dot-mod-mode instead of go-mod-mode to avoid tab completion
conflicts with go-mode* functions.

- It font locks key words and comments. 
- I just borrowed the existing go-mode indentation code since it already does the right thing for go.mod files.