### PR TITLE
Run all tests in GH CI

### DIFF
--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -14,4 +14,4 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Test
-      run: cd test; emacs --batch -q -l ert -l ../go-mode.el -l go-indentation-test.el -f ert-run-tests-batch-and-exit
+      run: cd test; emacs --batch -q -l ert -l ../go-mode.el $(for t in *-test.el; do echo -n "-l $t "; done) -f ert-run-tests-batch-and-exit

--- a/test/go-fill-paragraph-test.el
+++ b/test/go-fill-paragraph-test.el
@@ -4,6 +4,9 @@
 ;; Use of this source code is governed by a BSD-style
 ;; license that can be found in the LICENSE file.
 
+(require 'ert)
+(require 'go-mode)
+
 (defun go--should-fill (got expected)
   "Run `fill-paragraph' against GOT and make sure it matches EXPECTED.
 
@@ -15,9 +18,11 @@ represents point and mark to test the region based fill-paragraph."
     (goto-char (point-min))
     (let ((beg (progn (search-forward "<") (delete-char -1) (point)))
           (end (progn (search-forward ">") (delete-char -1) (point))))
-      (when (/= beg end)
-        (set-mark beg))
-      (call-interactively 'fill-paragraph)
+      (if (/= beg end)
+          (progn
+            (set-mark beg)
+            (call-interactively 'fill-region))
+        (call-interactively 'fill-paragraph))
       (should (string= (buffer-string) expected)))))
 
 (ert-deftest go--fill-paragraph-no-comment ()


### PR DESCRIPTION
And fix go-fill-paragraph-test.el to pass from the command line. Not
sure exactly what is wrong, but fill-paragraph wasn't doing the right
thing with a region selected when invoked from the command line. There
could be a real bug here, but I wasn't able to reproduce the failures
functionally in Emacs.

@go-mode-bot run