### PR TITLE
Improve imenu regex for multi-line func signatures

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1670,7 +1670,7 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
 
   (setq imenu-generic-expression
         '(("type" "^type *\\([^ \t\n\r\f]*\\)" 1)
-          ("func" "^func *\\(.*\\) {" 1)))
+          ("func" "^func *\\([^{]*\\) {" 1)))
   (imenu-add-to-menubar "Index")
 
   ;; Go style


### PR DESCRIPTION
Make the imenu func regex handle function signatures split across
multiple lines.

Fixes #57