### PR TITLE
Fix font locking in nested signatures.

### DIFF
--- a/test/go-font-lock-test.el
+++ b/test/go-font-lock-test.el
@@ -27,6 +27,9 @@
 
   (should-fontify "KfuncK(KinterfaceK { FfooF() }, TstringT) KinterfaceK{}")
 
+  (should-fontify "KfuncK(VaV TbT, VcV KfuncK(VdV *TeT) TdT) TfT")
+  (should-fontify "KfuncK(VaV KfuncK() TbT, VcV TdT)")
+
   (should-fontify "
 KfuncK FfooF(
   VaV TcatT, VbV KinterfaceK { FbarkF() },


### PR DESCRIPTION
We weren't font locking nested signatures such as:

func foo(i int, f func(b bool) string) float32

I fixed the param list fontification to jump back to the opening "("
after fontifying the list. This allows it to match param lists
contained within the outer list.

I also fixed the "single result" rule to properly match the "string"
in the above example. I had to break it out into a function to avoid
consuming the ")" after "string", which prevented it from matching the
following float32 result type.