### PR TITLE
Fix Content-Type for https://play.golang.org/share

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -2015,7 +2015,7 @@ code to the Playground. You can disable the confirmation by setting
 "
   (interactive "r")
   (if (and go-confirm-playground-uploads
-           (not (yes-or-no-p "Upload to public Go Playground?")))
+           (not (yes-or-no-p "Upload to public Go Playground? ")))
       (message "Upload aborted")
     (let* ((url-request-method "POST")
            (url-request-extra-headers

--- a/go-mode.el
+++ b/go-mode.el
@@ -2019,7 +2019,7 @@ code to the Playground. You can disable the confirmation by setting
       (message "Upload aborted")
     (let* ((url-request-method "POST")
            (url-request-extra-headers
-            '(("Content-Type" . "application/x-www-form-urlencoded")))
+            '(("Content-Type" . "text/plain; charset=UTF-8")))
            (url-request-data
             (encode-coding-string
              (buffer-substring-no-properties start end)


### PR DESCRIPTION
I pushed another unrelated commit because it's just a typo.