### PR TITLE
Fix fontification performance issue

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1321,7 +1321,8 @@ declarations are also included."
   (let (found-match)
     (while (and
             (not found-match)
-            (re-search-forward (concat "\\(\\_<" go-identifier-regexp "\\)?(") end t))
+            (re-search-forward (concat "\\(\\_<" go-identifier-regexp "\\)?(") end t)
+            (not (go-in-string-or-comment-p)))
       (save-excursion
         (goto-char (match-beginning 0))
 
@@ -1473,27 +1474,19 @@ gets highlighted by the font lock keyword."
            ;; We aren't on right side of equals sign.
            (not (go--looking-back-p "=")))
 
-           (or
-            ;; We are followed directly by comma.
-            (looking-at-p "[[:space:]]*,")
+          (setq found-match t)
 
-            ;; Or we are followed by a space and non-space (non-space
-            ;; might be a type name or "=").
-            (looking-at-p "[[:space:]]+[^[:space:]]"))
-
-           (setq found-match t)
-
-           ;; Unset match data subexpressions that don't apply based on
-           ;; the decl kind.
-           (let ((md (match-data)))
-             (cond
-              ((string= decl "var")
-               (setf (nth 4 md) nil (nth 5 md) nil (nth 6 md) nil (nth 7 md) nil))
-              ((string= decl "const")
-               (setf (nth 2 md) nil (nth 3 md) nil (nth 6 md) nil (nth 7 md) nil))
-              ((string= decl "type")
-               (setf (nth 2 md) nil (nth 3 md) nil (nth 4 md) nil (nth 5 md) nil)))
-             (set-match-data md)))
+          ;; Unset match data subexpressions that don't apply based on
+          ;; the decl kind.
+          (let ((md (match-data)))
+            (cond
+             ((string= decl "var")
+              (setf (nth 4 md) nil (nth 5 md) nil (nth 6 md) nil (nth 7 md) nil))
+             ((string= decl "const")
+              (setf (nth 2 md) nil (nth 3 md) nil (nth 6 md) nil (nth 7 md) nil))
+             ((string= decl "type")
+              (setf (nth 2 md) nil (nth 3 md) nil (nth 4 md) nil (nth 5 md) nil)))
+            (set-match-data md)))
 
          (t
           (save-match-data


### PR DESCRIPTION
When looking for the start of a param list, don't match "(" in
comments/strings. This was causing us to do a lot of extra work when
the comment was at the file scope.

What I think was happening was we would expand our multiline keyword
scope to the end of the buffer looking for the corresponding closing
")". This caused us to font lock much bigger parts of the buffer where
normally you only font lock a line or two at a time.