### PR TITLE
Improve commenting partial lines.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1610,6 +1610,23 @@ This is intended to be called from `before-change-functions'."
      (eq (char-before (- (point) 3)) ?a)
      (eq (char-before (- (point) 4)) ?c)))))
 
+(defun go--comment-region (beg end &optional arg)
+  "Switch to block comment when commenting a partial line."
+  (save-excursion
+    (goto-char beg)
+    (let ((beg-bol (line-beginning-position)))
+      (goto-char end)
+      (if (and
+           ;; beg and end are on the same line
+           (eq (line-beginning-position) beg-bol)
+           ;; end is not at end of line
+           (not (eq end (line-end-position))))
+          (let ((comment-start "/* ")
+                (comment-end " */")
+                (comment-padding ""))
+            (comment-region-default beg end arg))
+        (comment-region-default beg end arg)))))
+
 ;;;###autoload
 (define-derived-mode go-mode prog-mode "Go"
   "Major mode for editing Go source text.
@@ -1669,7 +1686,7 @@ If you're looking for even more integration with Go, namely
 on-the-fly syntax checking, auto-completion and snippets, it is
 recommended that you look at flycheck
 \(see URL `https://github.com/flycheck/flycheck') or flymake in combination
-with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
+with goflymake (see URL `https://github.com/dougm/goflymake'), gocode
 \(see URL `https://github.com/nsf/gocode'), go-eldoc
 \(see URL `github.com/syohex/emacs-go-eldoc') and yasnippet-go
 \(see URL `https://github.com/dominikh/yasnippet-go')"
@@ -1686,6 +1703,7 @@ with goflymake \(see URL `https://github.com/dougm/goflymake'), gocode
   (set (make-local-variable 'comment-end)   "")
   (set (make-local-variable 'comment-use-syntax) t)
   (set (make-local-variable 'comment-start-skip) "\\(//+\\|/\\*+\\)\\s *")
+  (set (make-local-variable 'comment-region-function) 'go--comment-region)
 
   (set (make-local-variable 'beginning-of-defun-function) #'go-beginning-of-defun)
   (set (make-local-variable 'end-of-defun-function) #'go-end-of-defun)

--- a/test/go-comment-test.el
+++ b/test/go-comment-test.el
@@ -1,0 +1,52 @@
+;;; go-comment-test.el
+
+;; Copyright 2020 The go-mode Authors. All rights reserved. Use of
+;; this source code is governed by a BSD-style license that can be
+;; found in the LICENSE file.
+
+(require 'ert)
+(require 'go-mode)
+(require 'cl-lib)
+
+(ert-deftest go--comment-region ()
+  (go--should-comment
+   "
+<var foo int
+>"
+   "
+// var foo int
+")
+
+  (go--should-comment
+   "
+<// var foo int
+>"
+   "
+var foo int
+")
+
+  (go--should-comment
+   "var <foo> int"
+   "var /* foo */ int")
+
+  (go--should-comment
+   "var </* foo */> int"
+   "var foo int"))
+
+(defun go--should-comment (got expected)
+  "Run `comment-dwim' against GOT and make sure it matches EXPECTED.
+
+<> in GOT represents point. If they aren't next to each other, then it
+represents point and mark to test the region based comment-region."
+  (with-temp-buffer
+    (go-mode)
+    (transient-mark-mode)
+    (insert got)
+    (goto-char (point-min))
+    (let ((beg (progn (search-forward "<") (delete-char -1) (point)))
+          (end (progn (search-forward ">") (delete-char -1) (point))))
+      (when (/= beg end)
+        (set-mark beg))
+      (goto-char end)
+      (call-interactively 'comment-dwim)
+      (should (string= (buffer-string) expected)))))

--- a/test/go-fill-paragraph-test.el
+++ b/test/go-fill-paragraph-test.el
@@ -14,15 +14,15 @@
 represents point and mark to test the region based fill-paragraph."
   (with-temp-buffer
     (go-mode)
+    (transient-mark-mode)
     (insert got)
     (goto-char (point-min))
     (let ((beg (progn (search-forward "<") (delete-char -1) (point)))
           (end (progn (search-forward ">") (delete-char -1) (point))))
-      (if (/= beg end)
-          (progn
-            (set-mark beg)
-            (call-interactively 'fill-region))
-        (call-interactively 'fill-paragraph))
+      (when (/= beg end)
+        (set-mark beg))
+      (goto-char end)
+      (call-interactively 'fill-paragraph)
       (should (string= (buffer-string) expected)))))
 
 (ert-deftest go--fill-paragraph-no-comment ()

--- a/test/go-font-lock-test.el
+++ b/test/go-font-lock-test.el
@@ -1,4 +1,4 @@
-;;; go-indentation-test.el
+;;; go-font-lock-test.el
 
 ;; Copyright 2019 The go-mode Authors. All rights reserved. Use of
 ;; this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
For example, say you want to comment out "&& bar" in:

if foo && bar {

}

Previously comment-dwim would cause:

if foo // && bar
{

}

which is a syntax error.

Now we notice if you are commenting within a single line and switch to
the /* */ block style comments, yielding:

if foo /* && bar */ {

}

I also think I figured out that region based tests require transient
mark mode, so change go--should-fill back to only call
fill-paragraph (which itself delegates to fill-region).