### PR TITLE
godoc-gogetdoc works with modules

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -289,9 +289,7 @@ You can install gogetdoc with 'go get -u github.com/zmb3/gogetdoc'."
       (error "Cannot use gogetdoc on a buffer without a file name"))
   (let ((posn (format "%s:#%d" (file-truename buffer-file-name) (1- (position-bytes point))))
         (out (godoc--get-buffer "<at point>")))
-  (with-current-buffer (get-buffer-create "*go-gogetdoc-input*")
-    (setq buffer-read-only nil)
-    (erase-buffer)
+  (with-temp-buffer
     (go--insert-modified-files)
     (call-process-region (point-min) (point-max) "gogetdoc" nil out nil
                          "-modified"


### PR DESCRIPTION
godoc-gogetdoc now works with modules outside GOPATH by creating a temporary buffer using with-temp-buffer, which preserves default-directory.