### PR TITLE
indent: fix func literals in dangling lines

### DIFF
--- a/test/testdata/indentation_tests/function_call.go
+++ b/test/testdata/indentation_tests/function_call.go
@@ -61,4 +61,20 @@ func _() {
 		1,
 	),
 	)
+
+	foo.
+		bar(func(i int) (a b) {
+
+		})
+
+	foo ||
+		bar &&
+			baz(func() {
+				X
+			})
+
+	foo &&
+		func() bool {
+			return X
+		}()
 }


### PR DESCRIPTION
Fix cases like:

foo &&
  bar(func() {
  X // Bad
  })

foo &&
  bar(func() {
    X // Good
  })

When computing indent for "X" we were misinterpreting the enclosing
"{" as a control flow block opener as in:

foo &&
  bar {
  X
}

Now we better differentiate func literal opening curlies and control
flow block curlies.

Fixes #332.