### PR TITLE
Speed up slow fontification after unclosed parens.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1333,9 +1333,15 @@ func foo(i, j int) {}
   ;; multiline param list.
   (save-excursion
     (let ((depth (go-paren-level)))
-      (while (and
-              (re-search-forward ")" nil t)
-              (>= (go-paren-level) depth))))
+      ;; First check that our paren is closed by the end of the file. This
+      ;; avoids expanding the fontification region to the entire file when you
+      ;; have an unclosed paren at file scope.
+      (when (save-excursion
+              (goto-char (1+ (buffer-size)))
+              (< (go-paren-level) depth))
+        (while (and
+                (re-search-forward ")" nil t)
+                (>= (go-paren-level) depth)))))
     (point)))
 
 (defun go--fontify-param-post ()


### PR DESCRIPTION
To handle multi line param lists we "expand" the fontification scope
to the closing paren. If there is no balanced closing paren then we
expand the scope to the end of the file, which fontifies too much
stuff and makes typing very slow.

For example, typing is slow at <>:

func (myReceive<>

... lots of lines in rest of file ...

Add a quick fix to check that the paren is closed by the end of the
file. If it isn't closed, then don't expand the region. There is more
work to do here (e.g. func literals inside giant functions will still
be slow), but this should resolve the worst slowness.

Fixes #335.