### PR TITLE
Only fontify ident keys in composite literals

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1621,18 +1621,22 @@ We are looking for the right-hand-side of the type alias"
             (not found-match)
             (re-search-forward go--label-re end t))
 
-      (setq found-match (or
-                         ;; Composite literal field names, e.g. "Foo{Bar:". Note
-                         ;; that this gives false positives for literal maps,
-                         ;; arrays, and slices.
-                         (go--in-composite-literal-p)
+      (save-excursion
+        (goto-char (match-beginning 1))
+        (skip-syntax-backward " ")
 
-                         ;; We are a label definition if we are at the beginning
-                         ;; of the line.
-                         (save-excursion
-                           (goto-char (match-beginning 1))
-                           (skip-syntax-backward " ")
-                           (bolp)))))
+        (setq found-match (or
+                           ;; We are a label/field name if we are at the
+                           ;; beginning of the line.
+                           (bolp)
+
+                           ;; Composite literal field names, e.g. "Foo{Bar:". Note
+                           ;; that this gives false positives for literal maps,
+                           ;; arrays, and slices.
+                           (and
+                            (or (eq (char-before) ?,) (eq (char-before) ?{))
+                            (go--in-composite-literal-p))))))
+
     found-match))
 
 (defun go--parameter-list-type (end)

--- a/test/go-font-lock-test.el
+++ b/test/go-font-lock-test.el
@@ -106,7 +106,13 @@ CbarC: baz,
 CbarC: baz,
 }, {
 CbarC: baz,
-}}"))
+}}")
+
+  (go--should-fontify "TsomeMapT{
+foo.Zar: baz,
+a + b: 3,
+a-b: 4,
+}"))
 
 (ert-deftest go--fontify-slices-arrays-maps ()
   (go--should-fontify "[]TfooT")


### PR DESCRIPTION
Previously we were fontifying things like selectors and binary
expressions in composite literals. For example, we fontified "baz" in:

foo{
  bar.baz: 123,
  bar + baz: 123,
}

Now we are more careful to only fontify composite literal key
identifiers preceded by "," or "{".