### PR TITLE
Allow leading spaces for compilation error message

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1825,7 +1825,7 @@ with goflymake (see URL `https://github.com/dougm/goflymake'), gocode
              (boundp 'compilation-error-regexp-alist-alist))
     (add-to-list 'compilation-error-regexp-alist 'go-test)
     (add-to-list 'compilation-error-regexp-alist-alist
-                 '(go-test . ("^\t+\\([^()\t\n]+\\):\\([0-9]+\\):? .*$" 1 2)) t)))
+                 '(go-test . ("^\\s-+\\([^()\t\n]+\\):\\([0-9]+\\):? .*$" 1 2)) t)))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist (cons "\\.go\\'" 'go-mode))


### PR DESCRIPTION
In compilation buffer, the error message from `go test` containing the file and line number may begin with spaces. My go version: `go1.14.1 darwin/amd64`.