### PR TITLE
Fix fontification of multiline type switch clauses.

### DIFF
--- a/test/go-font-lock-test.el
+++ b/test/go-font-lock-test.el
@@ -77,6 +77,10 @@ KmapK[TstringT]KinterfaceK{}{
 KswitchK foo.(KtypeK) {
 KcaseK TstringT, *Tfoo.ZebraT, [2]TbyteT:
 KcaseK CnilC:
+KcaseK TfooT, TbarT, D// DQhi
+Q
+  D// DQthere
+Q  TbazT, TquxT:
 KdefaultK:
 }")
 


### PR DESCRIPTION
Now we properly fontify "foo" and "bar" in:

    switch v.(type) {
    case foo,
      bar:
    }

I also tried to be careful so comments don't mess things up.