### PR TITLE
fix: go-guru-definition jump to wrong position by wrong coding-system.

### DIFF
--- a/go-guru.el
+++ b/go-guru.el
@@ -180,6 +180,7 @@ Parse and return the resulting JSON object."
     (unwind-protect
 	;; Run guru, feeding it the input buffer (modified files).
 	(with-current-buffer input-buffer
+	  (set-buffer-file-coding-system 'raw-text)
 	  (go-guru--insert-modified-files)
 	  (unless (buffer-file-name buf)
 	    (go-guru--insert-modified-file filename buf))


### PR DESCRIPTION
When default coding-system is "utf-8-unix" and open a file with "utf-8-dos"
coding-system, go-guru-definition will jump to wrong position.

This is because windows's EOL is "\r\n", is different with linux's "\n", so we
must keep the EOL unchanged when process internally.