### PR TITLE
compilation-mode: improve parsing of error messages.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1842,7 +1842,16 @@ with goflymake (see URL `https://github.com/dougm/goflymake'), gocode
              (boundp 'compilation-error-regexp-alist-alist))
     (add-to-list 'compilation-error-regexp-alist 'go-test)
     (add-to-list 'compilation-error-regexp-alist-alist
-                 '(go-test . ("^\\s-+\\([^()\t\n]+\\):\\([0-9]+\\):? .*$" 1 2)) t)))
+                 '(go-test . ("^\\s-+\\([^()\t\n]+\\):\\([0-9]+\\):? .*$" 1 2)) t)
+    (add-to-list 'compilation-error-regexp-alist 'go-compilation)
+    (add-to-list 'compilation-error-regexp-alist-alist
+                 '(go-compilation
+                   . ("^\\(\\([^\n]+\\):\\([0-9]+\\):\\([0-9]+\\)\\): " 2 3 4 nil 1)))
+    (add-to-list 'compilation-error-regexp-alist 'go-compilation-info)
+    (add-to-list 'compilation-error-regexp-alist-alist
+                 '(go-compilation-info
+                   . ("^\tprevious declaration at \\(\\([^\n]+\\):\\([0-9]+\\):\\([0-9]+\\)\\)"
+                      2 3 4 0 1)))))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist (cons "\\.go\\'" 'go-mode))


### PR DESCRIPTION
* parse location such as
	previous declaration at .\client.go:131:47

correctly, and make them information-level error (errors are
underlined by default in green and are skipped by next-error by default).

I did not find other error messages referencing locations in the compiler code, but I'll be glad to handle more if necessary.

* do not underline error message space following the last colon of the
  notation:

this underlining:
```
.\info.go:64:6: informative message
^^^^^^^^^^^^^^
```

rather than this one:
```
.\info.go:64:6: informative message
^^^^^^^^^^^^^^^^
```