### PR TITLE
Fix comment filling at start of buffer.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -845,9 +845,11 @@ thing for comments."
               (when mark-active
                 (setq arg (forward-paragraph arg)))
               (setq done t))
-          ;; If we are going backwards, back up one more line so
-          ;; we are on the line before the comment.
-          (when (= single -1)
+          ;; If we are going backwards, move forward one line so we
+          ;; are on the first interesting line of the comment. Note
+          ;; that the current line may already be interesting if we
+          ;; are at the beginning of the buffer.
+          (when (and (= single -1) (not (go--interesting-comment-p)))
             (forward-line 1))
           (cl-decf arg single))))
     arg))

--- a/test/go-fill-paragraph-test.el
+++ b/test/go-fill-paragraph-test.el
@@ -218,3 +218,21 @@ func main() {
 	if something() { somethingElse() }
 }"
    ))
+
+
+(ert-deftest go--fill-paragraph-bob ()
+  (go--should-fill
+   "<>// Lorem
+// ipsum."
+   "// Lorem ipsum."
+   )
+
+  (go--should-fill
+   "<>/*
+   Lorem
+   ipsum.
+*/"
+   "/*
+   Lorem ipsum.
+*/"
+   ))


### PR DESCRIPTION
In cases like:

    // Sweet
    // comment.
    package foo

We weren't filling the comment properly
because (go--fill-forward-paragraph -1) was ending up on the second
line instead of the first. It goes backwards to the first line with no
comment content and then moves forward one line, but at the beginning
of the buffer there is no line preceeding the comment. Tweak the logic
to not move forward if the current line has comment content.

Fixes #373.