### PR TITLE
Fix go.mod fontification.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -3006,7 +3006,7 @@ If BUFFER, return the number of characters in that buffer instead."
 (defvar go-dot-mod-font-lock-keywords
   `(
     (,(concat "^\\s-*\\(" (regexp-opt go-dot-mod-mode-keywords t) "\\)\\s-") 1 font-lock-keyword-face)
-    ("^\\s-*\\([^[:space:]]+\\)\\s-+\\(v[0-9]+\\.[0-9]+\\.[0-9]+\\)\\([^[:space:]\n]*\\)" (1 'go-dot-mod-module-name) (2 'go-dot-mod-module-semver) (3 'go-dot-mod-module-version)))
+    ("\\(?:^\\|=>\\)\\s-*\\([^[:space:]\n()]+\\)\\(?:\\s-+\\(v[0-9]+\\.[0-9]+\\.[0-9]+\\)\\([^[:space:]\n]*\\)\\)?" (1 'go-dot-mod-module-name) (2 'go-dot-mod-module-semver nil t) (3 'go-dot-mod-module-version nil t)))
   "Keyword highlighting specification for `go-dot-mod-mode'.")
 
 ;;;###autoload

--- a/test/go-font-lock-test.el
+++ b/test/go-font-lock-test.el
@@ -210,7 +210,13 @@ KgoK 1.13
 
 KrequireK (
   Nexample.com/require/go/bananaN Sv12.34.56SV-1234-456abcV D// DQindirect
-Q)
+Q	Nnoslash.devN Sv1.2.3S
+)
+
+KreplaceK (
+	Nfoo.example.com/barN Sv1.2.3S => Nfoo.example.com/barN Sv1.2.3S
+	Nexample.com/foo/barN => Nexample.com/baz/barN Sv0.0.0SV-20201112005413-933910cbaea0V
+)
 " 'go-dot-mod-mode))
 
 (defun go--should-match-face (want-face)


### PR DESCRIPTION
Tweak keyword regex so it always allows version after module name.
Both modules and versions are now fontified properly in:

    replace (
      example.com/foo v1.2.3 => example.com/bar v4.5.6
    )