### PR TITLE
Fix fontification of multiplicand after index expr.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -500,7 +500,7 @@ statements."
      (,(concat go-type-name-regexp "{") 1 font-lock-type-face)
 
      ;; Map value type
-     (,(concat "\\_<map\\_>\\[[^]]+\\]" go-type-name-regexp) 1 font-lock-type-face)
+     (go--match-map-value 1 font-lock-type-face)
 
      ;; Map key type
      (,(concat "\\_<map\\_>\\[" go-type-name-regexp) 1 font-lock-type-face)
@@ -1723,6 +1723,17 @@ We are looking for the right-hand-side of the type alias"
                          (go--in-paren-with-prefix-p ?\( "type"))))
     found-match))
 
+
+(defconst go--map-value-re
+  (concat "\\_<map\\_>\\[\\(?:\\[[^]]*\\]\\)*[^]]*\\]" go-type-name-regexp))
+
+(defun go--match-map-value (end)
+  "Search for map value types."
+  (when (re-search-forward go--map-value-re end t)
+    ;; Move point to beginning of map value in case value itself is
+    ;; also a map (we will match it next iteration).
+    (goto-char (match-beginning 1))
+    t))
 
 (defconst go--label-re (concat "\\(" go-label-regexp "\\):"))
 

--- a/go-mode.el
+++ b/go-mode.el
@@ -491,7 +491,7 @@ statements."
      (go--match-type-alias 2 font-lock-type-face)
 
      ;; Arrays/slices: []<type> | [123]<type> | [some.Const]<type> | [someConst]<type> | [...]<type>
-     (,(concat "\\[\\(?:[[:digit:]]+\\|" go-qualified-identifier-regexp "\\|" go-identifier-regexp "\\|\\.\\.\\.\\)?\\]" go-type-name-regexp) 1 font-lock-type-face)
+     (,(concat "\\(?:^\\|[^[:word:][:multibyte:]]\\)\\[\\(?:[[:digit:]]+\\|" go-qualified-identifier-regexp "\\|" go-identifier-regexp "\\|\\.\\.\\.\\)?\\]" go-type-name-regexp) 1 font-lock-type-face)
 
      ;; Unary "!"
      ("\\(!\\)[^=]" 1 font-lock-negation-char-face)

--- a/test/go-font-lock-test.el
+++ b/test/go-font-lock-test.el
@@ -126,6 +126,7 @@ a-b: 4,
   (go--should-fontify "[123]TfooT")
   (go--should-fontify "[...]TfooT")
   (go--should-fontify "[foo.Zar]TfooT")
+  (go--should-fontify "D/*DQhi*/Q[1]*TfooT")
 
   (go--should-fontify "KmapK[*Tfoo.ZarT]*Tbar.ZarT")
   (go--should-fontify "[]KmapK[TfooT]TbarT")
@@ -201,6 +202,10 @@ KforK {
   (go--should-fontify "VfooV, VbarV := baz, qux")
   (go--should-fontify "foo, bar = baz, qux")
   (go--should-fontify "KfuncK FfooF(ViV TintT) { VbarV := baz }"))
+
+(ert-deftest go--fontify-index-multiply ()
+  (go--should-fontify "foo[1]*10 + 1")
+  (go--should-fontify "foo[1]*foo[2] + 1"))
 
 (ert-deftest go--fontify-go-dot-mod ()
   (go--should-fontify "

--- a/test/go-font-lock-test.el
+++ b/test/go-font-lock-test.el
@@ -130,7 +130,9 @@ a-b: 4,
 
   (go--should-fontify "KmapK[*Tfoo.ZarT]*Tbar.ZarT")
   (go--should-fontify "[]KmapK[TfooT]TbarT")
-  (go--should-fontify "KmapK[[1][2][three]*Tfoo.ZarT][four][]*Tbar.ZarT"))
+  (go--should-fontify "KmapK[[1][2][three]*Tfoo.ZarT][four][]*Tbar.ZarT")
+  (go--should-fontify "KmapK[TstringT]KmapK[TstringT]Tfloat64T")
+  (go--should-fontify "KmapK[[2][c]*TintT]TboolT"))
 
 (ert-deftest go--fontify-negation ()
   ;; Fontify unary "!".


### PR DESCRIPTION
In "foo[1]*10" we were interpreting "[1]*10" as an array with element
type "*10". At first I was going to fix the identifier regex to
disallow leading numbers (so "10" couldn't be a type name), but that
is involved and doesn't fix the similar case of "foo[1]*foo[2]".
Instead fix the array type detection to disallow an identifier
character preceding the opening bracket.

Fixes #382.