### PR TITLE
Add dependency on Emacs 26.1

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -9,6 +9,7 @@
 ;; Author: The go-mode Authors
 ;; Version: 1.5.0
 ;; Keywords: languages go
+;; Package-Requires: ((emacs "26.1"))
 ;; URL: https://github.com/dominikh/go-mode.el
 ;;
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
This adds an explicit dependency on Emacs 26.1. According to `package-lint-current-buffer` in `go-mode.el`:

```
1930:18: error: You should depend on (emacs "26.1") if you need `make-nearby-temp-file'.
1956:43: error: You should depend on (emacs "26.1") if you need `file-local-name'.
1960:36: error: You should depend on (emacs "26.1") if you need `file-local-name'.
2004:46: error: You should depend on (emacs "26.1") if you need `file-local-name'.
```

There is also a dependency on xref, which was first included in Emacs 25.1. Thanks. 

EDIT: I also see that you now intend to depend on Emacs 26.1 (https://github.com/dominikh/go-mode.el/commit/32cbd78c0af29837ace3db04a224d6d01ec6851e).