### PR TITLE
Bump version to 1.6.0 for NonGNU ELPA

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -7,7 +7,7 @@
 ;; license that can be found in the LICENSE file.
 
 ;; Author: The go-mode Authors
-;; Version: 1.5.0
+;; Version: 1.6.0
 ;; Keywords: languages go
 ;; URL: https://github.com/dominikh/go-mode.el
 ;;


### PR DESCRIPTION
Hi!

This package has been added [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";; Version: NNN" commentary header in this repository, as I do in this commit. It was five years since that header was last updated. Note also that NonGNU ELPA does not look at any "git tag".

In the future, you can bump the package version in the "Version" header (thereby releasing a new version) when you think it makes sense and at your convenience.

Thanks!