### PR TITLE
Remove go--fill-prefix

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -733,31 +733,6 @@ case keyword. It returns nil for the case line itself."
   "Return non-nil if point is inside a type switch statement."
   (go--in-paren-with-prefix-p ?{ ".(type)"))
 
-(defun go--fill-prefix ()
-  "Return fill prefix for following comment paragraph."
-  (save-excursion
-    (beginning-of-line)
-
-    ;; Skip over empty lines and empty comment openers/closers.
-    (while (and
-            (or (go--empty-line-p) (go--boring-comment-p))
-            (zerop (forward-line 1))))
-
-    ;; If we are in a block comment, set prefix based on first line
-    ;; with content.
-    (if (go-in-comment-p)
-        (progn
-          (looking-at "[[:space:]]*")
-          (match-string-no-properties 0))
-
-      ;; Else if we are looking at the start of an interesting comment, our
-      ;; prefix is the comment opener and any space following.
-      (if (looking-at (concat go--comment-start-regexp "[[:space:]]*"))
-          ;; Replace "/*" opener with spaces so following lines don't
-          ;; get "/*" prefix.
-          (replace-regexp-in-string "/\\*" "  "
-                                    (match-string-no-properties 0))))))
-
 (defun go--open-paren-position ()
   "Return non-nil if point is between '(' and ')'.
 


### PR DESCRIPTION
The function is not called from anywhere and does not work as it calls
function that were previously deleted. Both go--empty-line-p and
go--boring-comment-p were removed in
b212a73c21a8b806f9764004397c1d03eb0b2e10.