### PR TITLE
Fix false positive type alias fontification.

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1614,7 +1614,7 @@ func foo(i int) string"
     found-match))
 
 (defconst go--type-alias-re
-  (concat "^[[:space:]]*\\(type\\)?[[:space:]]*" go-identifier-regexp "[[:space:]]*=[[:space:]]*" go-type-name-regexp))
+  (concat "^[[:space:]]*\\(type[[:space:]]+\\)?" go-identifier-regexp "[[:space:]]*=[[:space:]]*" go-type-name-regexp))
 
 (defun go--match-type-alias (end)
   "Search for type aliases.

--- a/test/go-font-lock-test.el
+++ b/test/go-font-lock-test.el
@@ -158,7 +158,9 @@ KtypeK (
   TfooT TbarT
   TfooT KstructK {}
   TfooT = *Tbar.ZarT
-)"))
+)")
+
+  (go--should-fontify "typeName = abc"))
 
 (ert-deftest go--fontify-var-decl ()
   (go--should-fontify "KvarK VfooV = bar")


### PR DESCRIPTION
We were interpreting "typeFoo = 123" as a type alias due to a bug in
the regex.