### PR TITLE
Use Eask for CI

### DIFF
--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -4,14 +4,33 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    runs-on: ${{ matrix.os }}
+      strategy:
+      fail-fast: false
+        matrix:
+          os: [ubuntu-latest, macos-latest, windows-latest]
+          emacs-version:
+            - 26.3
+            - 27.2
+            - 28.1
+            - snapshot
+
     steps:
     - name: Install emacs
-      run: sudo apt-get update && sudo apt-get install -y emacs
+      uses: jcs090218/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Test
-      run: cd test; emacs --batch -q -l ert -l ../go-mode.el $(for t in *-test.el; do echo -n "-l $t "; done) -f ert-run-tests-batch-and-exit
+      run: make ci

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -1,7 +1,12 @@
 name: Emacs CI
-on: [push, pull_request]
-jobs:
 
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -5,15 +5,15 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
-      strategy:
-        fail-fast: false
-        matrix:
-          os: [ubuntu-latest, macos-latest, windows-latest]
-          emacs-version:
-            - 26.3
-            - 27.2
-            - 28.1
-            - snapshot
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
+          - 26.3
+          - 27.2
+          - 28.1
+          - snapshot
 
     steps:
     - name: Install emacs

--- a/.github/workflows/emacs.yml
+++ b/.github/workflows/emacs.yml
@@ -6,7 +6,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
       strategy:
-      fail-fast: false
+        fail-fast: false
         matrix:
           os: [ubuntu-latest, macos-latest, windows-latest]
           emacs-version:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.elc
+.eask
+/dist

--- a/Eask
+++ b/Eask
@@ -8,3 +8,5 @@
 (source "melpa")
 
 (depends-on "emacs" "26.1")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Eask
+++ b/Eask
@@ -5,5 +5,6 @@
 (package-file "go-mode.el")
 
 (source "gnu")
+(source "melpa")
 
 (depends-on "emacs" "26.1")

--- a/Eask
+++ b/Eask
@@ -2,7 +2,10 @@
          "1.6.0"
          "Major mode for the Go programming language")
 
-(package-file "go-mode.el")
+;; XXX: this is multiple-packages-in-on-repository
+;;
+;; Ignore this to get the package-lint to work
+;;(package-file "go-mode.el")
 
 (files "*.el")
 

--- a/Eask
+++ b/Eask
@@ -4,6 +4,8 @@
 
 (package-file "go-mode.el")
 
+(files "*.el")
+
 (source "gnu")
 (source "melpa")
 

--- a/Eask
+++ b/Eask
@@ -1,0 +1,9 @@
+(package "go-mode.el"
+         "1.6.0"
+         "Major mode for the Go programming language")
+
+(package-file "go-mode.el")
+
+(source "gnu")
+
+(depends-on "emacs" "26.1")

--- a/Eask
+++ b/Eask
@@ -1,4 +1,4 @@
-(package "go-mode.el"
+(package "go-mode"
          "1.6.0"
          "Major mode for the Go programming language")
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EASK ?= eask
 # CI entry point
 #
 # You can add or remove any commands here
-ci: clean package install compile checkdoc test
+ci: clean package install compile checkdoc lint test
 
 # Build an package artefact, default to `dist` folder
 #

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-##
-# Eask generated template Makefile
-#
-# File located in https://github.com/emacs-eask/template-elisp/blob/master/Makefile
-##
-
 SHELL := /usr/bin/env bash
 
 EMACS ?= emacs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,86 @@
+##
+# Eask generated template Makefile
+#
+# File located in https://github.com/emacs-eask/template-elisp/blob/master/Makefile
+##
+
+SHELL := /usr/bin/env bash
+
+EMACS ?= emacs
+EASK ?= eask
+
+.PHONY: clean package install compile test checkdoc lint
+
+# CI entry point
+#
+# You can add or remove any commands here
+ci: clean package install compile checkdoc lint test
+
+# Build an package artefact, default to `dist` folder
+#
+# This is used to test if your package can be built correctly before the
+# package installation.
+package:
+	@echo "Packaging..."
+	$(EASK) package
+
+# Install package
+#
+# If your package is a single file package, you generally wouldn't need to 
+install:
+	@echo "Installing..."
+	$(EASK) install
+
+# Byte-compile package
+#
+# Compile all your package .el files to .elc
+compile:
+	@echo "Compiling..."
+	$(EASK) compile
+
+# Run regression tests
+#
+# The default test is `ert`; but Eask also support other regression test!
+# See https://emacs-eask.github.io/Getting-Started/Commands-and-options/#-linter
+test:
+	@echo "Testing..."
+	$(EASK) install-deps --dev
+	$(EASK) ert ./test/*.el
+
+# Run checkdoc
+#
+# See https://www.emacswiki.org/emacs/CheckDoc
+checkdoc:
+	@echo "Checking documentation..."
+	$(EASK) checkdoc
+
+# Lint package metadata
+#
+# See https://github.com/purcell/package-lint
+lint:
+	@echo "Linting..."
+	$(EASK) lint
+
+# Generate autoloads file
+#
+# NOTE: This is generally unnecessary
+autoloads:
+	@echo "Generating autoloads..."
+	$(EASK) autoloads
+
+# Generate -pkg file
+#
+# NOTE: This is generally unnecessary
+pkg-file:
+	@echo "Generating -pkg file..."
+	$(EASK) pkg-file
+
+# Clean up
+#
+# This will clean all the entire workspace including the following folders
+# and files
+#
+#   - .eask folder (sandbox)
+#   - all .elc files
+clean:
+	$(EASK) clean-all

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ EASK ?= eask
 # CI entry point
 #
 # You can add or remove any commands here
-ci: clean package install compile checkdoc lint test
+ci: clean package install compile checkdoc test
 
 # Build an package artefact, default to `dist` folder
 #

--- a/go-guru.el
+++ b/go-guru.el
@@ -5,7 +5,8 @@
 ;; license that can be found in the LICENSE file.
 
 ;; Version: 0.1
-;; Package-Requires: ((go-mode "1.3.1") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "26.1") (go-mode "1.3.1") (cl-lib "0.5"))
+;; URL: https://github.com/dominikh/go-mode.el
 ;; Keywords: tools
 
 ;;; Commentary:

--- a/go-rename.el
+++ b/go-rename.el
@@ -5,7 +5,8 @@
 ;; license that can be found in the LICENSE file.
 
 ;; Version: 0.1
-;; Package-Requires: ((go-mode "1.3.1"))
+;; Package-Requires: ((emacs "26.1") (go-mode "1.3.1"))
+;; URL: https://github.com/dominikh/go-mode.el
 ;; Keywords: tools
 
 ;;; Commentary:
@@ -80,7 +81,7 @@ the `gorename' tool. With FORCE, call `gorename' with the
       ;; and hide the *go-rename* buffer.
       (if success
           (progn
-            (message "%s" (go--buffer-string-no-trailing-space))
+            (message "%s" (go-rename--buffer-string-no-trailing-space))
             (gofmt--kill-error-buffer (current-buffer)))
         ;; failure
         (let ((w (display-buffer (current-buffer))))
@@ -100,7 +101,7 @@ the `gorename' tool. With FORCE, call `gorename' with the
     (forward-char col)))
 
 
-(defun go--buffer-string-no-trailing-space ()
+(defun go-rename--buffer-string-no-trailing-space ()
   (replace-regexp-in-string "[\t\n ]*\\'"
                             ""
                             (buffer-substring (point-min) (point-max))))

--- a/test/go-indentation-test.el
+++ b/test/go-indentation-test.el
@@ -8,7 +8,7 @@
 (require 'go-mode)
 
 (ert-deftest go--indent-line ()
-  (dolist (file (directory-files (expand-file-name "testdata/indentation_tests/") t ".*\\.go$"))
+  (dolist (file (directory-files (expand-file-name "test/testdata/indentation_tests/") t ".*\\.go$"))
     (with-temp-buffer
       (go-mode)
       (insert-file-contents file)
@@ -19,7 +19,7 @@
 (ert-deftest go-dot-mod--indent-line ()
   (with-temp-buffer
     (go-dot-mod-mode)
-    (insert-file-contents "testdata/indentation_tests/go.mod")
+    (insert-file-contents "test/testdata/indentation_tests/go.mod")
     (let ((contents-before-indent (buffer-string)) (inhibit-message t))
       (indent-region (point-min) (point-max) nil)
       (should (string= contents-before-indent (buffer-string))))))


### PR DESCRIPTION
This patch does the following:

#### In `.github/workflow/emacs.yml`

* Use `jcs090218/setup-emacs` to install Emacs (cross-platforms)
* Add setup-node (`16`)
* Add `setup-eask`
* Specified test Emacs version `26.x`, `27.x`, `28.x`, and `snapshot`
* Add tests on `Windows` and `macOS`
* Move `emacs --batch ... ert ...` test to `Makefile`

#### In `Makefile` (newly added)

* Add `make compile` to test byte-compile
* Add `make package` to test packaging
* Add `make install`  to test installing
* Add `make checkdoc` to check documentation and style
* Add `make lint` to do `package-lint`
* Add `make test` for `ert` test (moved from `emacs.yml`)

#### In `test/go-indentation-test.el`

* Fix the test path relative to project root

#### Others

* Add `Eask`-file

---

This is totally optional, I think this would make CI a lot easier. :)