### PR TITLE
Remove duplicate test.

### DIFF
--- a/test/go-fill-paragraph-test.el
+++ b/test/go-fill-paragraph-test.el
@@ -139,20 +139,6 @@ func main() {
 }"
    ))
 
-(ert-deftest go--fill-paragraph-block-region ()
-  (go--should-fill
-   "
-func main() {
-<  /* Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. */
->}"
-
-   "
-func main() {
-  /* Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-     eiusmod tempor incididunt ut labore et dolore magna aliqua. */
-}"
-   ))
-
 (ert-deftest go--fill-paragraph-single-artful ()
   (go--should-fill
    "


### PR DESCRIPTION
Emacs 29 doesn’t allow duplicate tests in batch mode.