### PR TITLE
builtins: add new go 1.21 builtins

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -97,9 +97,10 @@ constant is changed.")
 (defconst go--case-or-default-regexp (concat "\\(" go--case-regexp "\\|"  "[[:space:]]*default:\\)"))
 
 (defconst go-builtins
-  '("append" "cap"   "close"   "complex" "copy"
-    "delete" "imag"  "len"     "make"    "new"
-    "panic"  "print" "println" "real"    "recover")
+  '("append"  "cap"    "clear"   "close" "complex"
+    "copy"    "delete" "imag"    "len"   "make"
+    "max"     "min"    "new"     "panic" "print"
+    "println" "real"   "recover")
   "All built-in functions in the Go language.  Used for font locking.")
 
 (defconst go-mode-keywords


### PR DESCRIPTION
This adds `min`, `max`, and `clear`, as per: https://tip.golang.org/doc/go1.21#language