### PR TITLE
Fix obsoleted function warnings for newer Emacs

### DIFF
--- a/go-guru.el
+++ b/go-guru.el
@@ -318,7 +318,7 @@ If BUFFER, return the number of characters in that buffer instead."
 
 (defun go-guru--goto-byte-column (offset)
   "Go to the OFFSETth byte in the current line."
-  (goto-char (byte-to-position (+ (position-bytes (point-at-bol)) (1- offset)))))
+  (goto-char (byte-to-position (+ (position-bytes (line-beginning-position)) (1- offset)))))
 
 (defun go-guru--goto-pos (posn other-window)
   "Find the file containing the position POSN (of the form `file:line:col')


### PR DESCRIPTION
There is the following byte-compile warning on Emacs 29 or higher versions. This patch fixes it.

```
In go-guru--goto-byte-column:
go-guru.el:321:52: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
```