### PR TITLE
Fix gofmt error handler on non-file buffer

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -1957,7 +1957,7 @@ arguments can be set as a list via ‘gofmt-args’."
                   (message "Applied gofmt"))
                 (if errbuf (gofmt--kill-error-buffer errbuf)))
             (message "Could not apply gofmt")
-            (if errbuf (gofmt--process-errors (buffer-file-name) tmpfile errbuf))))
+            (if errbuf (gofmt--process-errors (or buffer-file-name (buffer-name)) tmpfile errbuf))))
 
       (kill-buffer patchbuf)
       (delete-file tmpfile))))


### PR DESCRIPTION
When parsing error occur while formatting a non-file buffer. It'll cause a *real* error because we're trying to pass `buffer-file-name` which is null to `gofmt--process-errors` and `gofmt--process-errors` is trying to get `file-name` of that value. This commit pass `buffer-name` to `gofmt--process-errors` if current buffer is non-file.