### PR TITLE
Add go-{browse-{freesymbols,doc,assembly},rename}

### DIFF
--- a/go-mode.el
+++ b/go-mode.el
@@ -3051,6 +3051,45 @@ This handles multi-line comments with a * prefix on each line."
 
 
 
+;; Convenient go-* functions for gopls features available through code
+;; actions, that work across LSP clients:
+
+(defun go-mode--code-action (kind)
+  "Request and invoke the specified kind of code actions for the current selection."
+  (cond
+   ((and (boundp 'eglot--managed-mode) eglot--managed-mode)
+    (let ((beg-end (eglot--code-action-bounds)))
+      (eglot-code-actions (car beg-end) (cadr beg-end) kind t)))
+   ((and (boundp 'lsp-mode) lsp-mode)
+    (lsp-execute-code-action-by-kind kind))
+   (error "buffer is not managed by a known LSP client")))
+
+(defun go-browse-freesymbols ()
+  "View free symbols referenced by the current selection in a browser. Requires gopls v0.16."
+  (interactive)
+  (go-mode--code-action "source.freesymbols"))
+
+(defun go-browse-doc ()
+  "View documentation for the current Go package in a browser. Requires gopls v0.16."
+  (interactive)
+  (go-mode--code-action "source.doc"))
+
+(defun go-browse-assembly ()
+  "View assembly for the enclosing Go function in a browser. Requires gopls v0.16."
+  (interactive)
+  (go-mode--code-action "source.assembly"))
+
+(defun go-rename ()
+  "Rename a Go symbol, prompting for the new name."
+  (interactive)
+  (cond
+   ((and (boundp 'eglot--managed-mode) eglot--managed-mode)
+    (call-interactively #'eglot-rename))
+   ((and (boundp 'lsp-mode) lsp-mode)
+    (call-interactively #'lsp-rename))
+   (error "buffer is not managed by a known LSP client")))
+
+
 (provide 'go-mode)
 
 ;;; go-mode.el ends here


### PR DESCRIPTION
These four helper functions provide convenient ways to access gopls server functionality without the user needing to worry about how their LSP client does things. They should work for eglot and lsp-mode (though I haven't tested the latter).

Updates dominikh/go-mode.el/#436